### PR TITLE
feat: 검색어 조회/저장 기능 구현

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/RecentSearchController.java
+++ b/src/main/java/com/YOGIITSU/controller/RecentSearchController.java
@@ -1,0 +1,55 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.InvalidTokenException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.MissingTokenException;
+import com.YOGIITSU.dto.RequestDto.SearchKeywordRequestDto;
+import com.YOGIITSU.dto.ResponseDto.RecentSearchResponseDto;
+import com.YOGIITSU.service.RecentSearchService;
+import com.YOGIITSU.jwt.JwtTokenProvider;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
+public class RecentSearchController {
+
+	private final RecentSearchService recentSearchService;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	/**
+	 * 검색어 저장 API
+	 *
+	 * @param request 요청 데이터 (검색어)
+	 * @return message 응답 메시지
+	 */
+	@PostMapping("/save")
+	public ResponseEntity<Map<String, String>> saveSearchKeyword(
+		@RequestBody SearchKeywordRequestDto request, HttpServletRequest httpRequest) {
+
+		// 1. JWT 토큰 검증
+		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+		if (accessToken == null) {
+			throw new MissingTokenException();
+		}
+		if (!jwtTokenProvider.validateToken(accessToken)) {
+			throw new InvalidTokenException();
+		}
+
+		// 2. 사용자 ID 추출
+		String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
+
+		// 3. 검색어 저장
+		recentSearchService.saveSearchKeyword(memberId, request.getKeyword());
+
+		// 4. 응답 반환
+		Map<String, String> response = new HashMap<>();
+		response.put("message", "검색어가 저장되었습니다.");
+		return ResponseEntity.ok(response);
+	}

--- a/src/main/java/com/YOGIITSU/controller/RecentSearchController.java
+++ b/src/main/java/com/YOGIITSU/controller/RecentSearchController.java
@@ -53,3 +53,29 @@ public class RecentSearchController {
 		response.put("message", "검색어가 저장되었습니다.");
 		return ResponseEntity.ok(response);
 	}
+
+	/**
+	 * 최근 검색어 조회 API
+	 *
+	 * @return 최근 검색어 목록
+	 */
+	@GetMapping("/recent")
+	public ResponseEntity<List<RecentSearchResponseDto>> getRecentSearches(
+		HttpServletRequest httpRequest) {
+
+		// 1. JWT 토큰 검증
+		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+		if (accessToken == null) {
+			throw new MissingTokenException();
+		}
+		if (!jwtTokenProvider.validateToken(accessToken)) {
+			throw new InvalidTokenException();
+		}
+
+		// 2. 사용자 ID 추출
+		String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
+
+		// 3. 최근 검색어 조회 후 반환
+		return ResponseEntity.ok(recentSearchService.getRecentSearches(memberId));
+	}
+}

--- a/src/main/java/com/YOGIITSU/dto/RequestDto/SearchKeywordRequestDto.java
+++ b/src/main/java/com/YOGIITSU/dto/RequestDto/SearchKeywordRequestDto.java
@@ -1,0 +1,12 @@
+package com.YOGIITSU.dto.RequestDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+
+public class SearchKeywordRequestDto {
+
+	private String keyword;
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/RecentSearchResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/RecentSearchResponseDto.java
@@ -1,0 +1,20 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import com.YOGIITSU.entity.RecentSearch;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RecentSearchResponseDto {
+
+	private String keyword;
+	private LocalDateTime searchedAt;
+
+	public RecentSearchResponseDto(RecentSearch recentSearch) {
+		this.keyword = recentSearch.getKeyword();
+		this.searchedAt = recentSearch.getSearchedAt();
+	}
+}

--- a/src/main/java/com/YOGIITSU/entity/RecentSearch.java
+++ b/src/main/java/com/YOGIITSU/entity/RecentSearch.java
@@ -1,0 +1,29 @@
+package com.YOGIITSU.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "recent_search",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "keyword"}))
+public class RecentSearch {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Column(name = "keyword", nullable = false, length = 100)
+	private String keyword;
+
+	@Column(name = "searched_at", nullable = false)
+	private LocalDateTime searchedAt;
+}

--- a/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
@@ -1,0 +1,17 @@
+package com.YOGIITSU.repository;
+
+import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.entity.RecentSearch;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long> {
+
+	// 최근 검색어 조회
+	List<RecentSearch> findByMemberOrderBySearchedAtDesc(Member member);
+
+	// 검색어 삭제
+	void deleteByMemberAndKeyword(Member member, String keyword);
+}

--- a/src/main/java/com/YOGIITSU/service/RecentSearchService.java
+++ b/src/main/java/com/YOGIITSU/service/RecentSearchService.java
@@ -1,0 +1,45 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.dto.ResponseDto.RecentSearchResponseDto;
+import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.entity.RecentSearch;
+import com.YOGIITSU.repository.MemberRepository;
+import com.YOGIITSU.repository.RecentSearchRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecentSearchService {
+
+	private final RecentSearchRepository recentSearchRepository;
+	private final MemberRepository memberRepository;
+
+	//최근 검색어 저장
+	@Transactional
+	public void saveSearchKeyword(String memberId, String keyword) {
+		Member member = memberRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+		// 기존에 같은 검색어가 있으면 삭제
+		recentSearchRepository.deleteByMemberAndKeyword(member, keyword);
+
+		// 최대 개수(6개) 초과 시 가장 오래된 검색어 삭제
+		List<RecentSearch> recentSearches = recentSearchRepository.findByMemberOrderBySearchedAtDesc(
+			member);
+		if (recentSearches.size() >= 6) {
+			recentSearchRepository.delete(recentSearches.getLast());
+		}
+
+		// 새로운 검색어 저장
+		RecentSearch search = RecentSearch.builder()
+			.member(member)
+			.keyword(keyword)
+			.searchedAt(LocalDateTime.now())
+			.build();
+		recentSearchRepository.save(search);
+	}

--- a/src/main/java/com/YOGIITSU/service/RecentSearchService.java
+++ b/src/main/java/com/YOGIITSU/service/RecentSearchService.java
@@ -43,3 +43,16 @@ public class RecentSearchService {
 			.build();
 		recentSearchRepository.save(search);
 	}
+
+	// 최근 검색어 조회
+	@Transactional(readOnly = true)
+	public List<RecentSearchResponseDto> getRecentSearches(String memberId) {
+		Member member = memberRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+		return recentSearchRepository.findByMemberOrderBySearchedAtDesc(member)
+			.stream()
+			.map(RecentSearchResponseDto::new)
+			.toList();
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`feature/search` → `develop`

### 변경 사항

- `RecentSearchController`에 **최근 검색어 조회 API** 추가

    - JWT 토큰을 검증하여 사용자별 검색어 목록 반환
    - 검색어가 없을 경우 빈 리스트 반환
- `RecentSearchService`에 **검색어 조회 로직 구현**

    - `RecentSearchRepository`를 활용하여 사용자 검색어 목록 조회
    - 검색어 조회 시 최신순 정렬 적용
    
- `RecentSearchRepository`에 **검색어 조회 및 삭제 기능 추가**

    - 특정 사용자의 검색 기록을 조회하는 메서드 추가
    - 일정 개수 이상의 검색어가 저장되면 가장 오래된 검색어 삭제

### 테스트 결과

- **Postman을 활용하여 최근 검색어 조회 API 정상 응답 확인**

    - JWT 포함 요청 시 정상적으로 검색어 목록 반환
    - 검색어가 없을 경우 빈 리스트 반환 확인
    
- **데이터 저장 및 삭제 검증**
    - 검색어를 연속 입력한 후 최신순으로 조회되는지 확인
    - 일정 개수 초과 시 (6개) 오래된 검색어가 자동 삭제되는지 검증