### PR TITLE
feat: 자동완성 검색어 추천 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-	implementation 'com.h2database:h2:2.1.214'
+	implementation 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
 	//JWT 토큰 라이브러리
@@ -39,7 +39,6 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/YOGIITSU/controller/SearchSuggestionController.java
+++ b/src/main/java/com/YOGIITSU/controller/SearchSuggestionController.java
@@ -1,0 +1,58 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.InvalidTokenException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.MissingTokenException;
+import com.YOGIITSU.dto.ResponseDto.SearchSuggestionResponseDto;
+import com.YOGIITSU.jwt.JwtTokenProvider;
+import com.YOGIITSU.service.SearchSuggestionService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.Collections;
+
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
+public class SearchSuggestionController {
+
+	private final SearchSuggestionService searchSuggestionService;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	/**
+	 * 자동완성 검색어 추천 API
+	 *
+	 * @param query 검색어
+	 * @return 검색어 추천 목록
+	 */
+	@GetMapping("/suggestions")
+	public ResponseEntity<List<SearchSuggestionResponseDto>> getSearchSuggestions(
+		@RequestParam(required = false) String query,
+		HttpServletRequest httpRequest) {
+
+		// 1. JWT 토큰 검증
+		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+		if (accessToken == null) {
+			throw new MissingTokenException();
+		}
+		if (!jwtTokenProvider.validateToken(accessToken)) {
+			throw new InvalidTokenException();
+		}
+
+		// 2. 검색어가 없거나 공백만 있는 경우 빈 리스트 반환
+		if (query == null || query.isBlank()) {
+			return ResponseEntity.ok(Collections.emptyList());
+		}
+
+		// 3. 사용자 ID 추출
+		String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
+
+		// 4. 자동완성 검색어 반환
+		return ResponseEntity.ok(searchSuggestionService.getSearchSuggestions(query, memberId));
+	}
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/SearchSuggestionResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/SearchSuggestionResponseDto.java
@@ -1,0 +1,11 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SearchSuggestionResponseDto {
+	private String keyword;
+	private boolean isBookmarked;
+}

--- a/src/main/java/com/YOGIITSU/repository/BuildingRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/BuildingRepository.java
@@ -1,8 +1,12 @@
 package com.YOGIITSU.repository;
 
 import com.YOGIITSU.entity.Building;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BuildingRepository extends JpaRepository<Building, Long> {
+
+	// 입력된 검색어(query)가 포함된 건물 이름을 최대 6개까지 반환
+	List<Building> findTop6ByNameContainingOrderByNameAsc(String query);
 
 }

--- a/src/main/java/com/YOGIITSU/service/SearchSuggestionService.java
+++ b/src/main/java/com/YOGIITSU/service/SearchSuggestionService.java
@@ -1,0 +1,45 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.dto.ResponseDto.SearchSuggestionResponseDto;
+import com.YOGIITSU.entity.Building;
+import com.YOGIITSU.entity.Favorite;
+import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.repository.BuildingRepository;
+import com.YOGIITSU.repository.FavoriteRepository;
+import com.YOGIITSU.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchSuggestionService {
+
+	private final BuildingRepository buildingRepository;
+	private final FavoriteRepository favoriteRepository;
+	private final MemberRepository memberRepository;
+
+	// 자동완성 검색어 추천
+	public List<SearchSuggestionResponseDto> getSearchSuggestions(String query, String memberId) {
+		// 1. 입력된 검색어가 포함된 단과대 리스트 조회 (최대 6개)
+		List<Building> buildings = buildingRepository.findTop6ByNameContainingOrderByNameAsc(query);
+
+		// 2. 현재 사용자의 즐겨찾기 목록 조회
+		Member member = memberRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+		List<Favorite> favorites = favoriteRepository.findByMember(member);
+		List<Long> bookmarkedBuildingIds = favorites.stream()
+			.map(favorite -> favorite.getBuilding().getId())
+			.toList();
+
+		// 3. 검색 결과와 즐겨찾기 여부 매핑
+		return buildings.stream()
+			.map(building -> new SearchSuggestionResponseDto(
+				building.getName(),
+				bookmarkedBuildingIds.contains(building.getId()) // 즐겨찾기 여부 확인
+			))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/YOGIITSU/service/SearchSuggestionService.java
+++ b/src/main/java/com/YOGIITSU/service/SearchSuggestionService.java
@@ -8,7 +8,9 @@ import com.YOGIITSU.repository.BuildingRepository;
 import com.YOGIITSU.repository.FavoriteRepository;
 import com.YOGIITSU.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,25 +23,59 @@ public class SearchSuggestionService {
 	private final FavoriteRepository favoriteRepository;
 	private final MemberRepository memberRepository;
 
-	// 자동완성 검색어 추천
 	public List<SearchSuggestionResponseDto> getSearchSuggestions(String query, String memberId) {
-		// 1. 입력된 검색어가 포함된 단과대 리스트 조회 (최대 6개)
-		List<Building> buildings = buildingRepository.findTop6ByNameContainingOrderByNameAsc(query);
+		// 1. 사용자 정보 조회
+		Member member = findMemberById(memberId);
 
-		// 2. 현재 사용자의 즐겨찾기 목록 조회
-		Member member = memberRepository.findByMemberId(memberId)
+		// 2. 사용자의 즐겨찾기된 건물 목록 가져오기 (즐겨찾기된 건물 중 검색어 포함된 것)
+		List<Building> bookmarkedBuildings = findBookmarkedBuildings(member, query);
+
+		// 3. DB에서 검색어가 포함된 건물 리스트 가져오기
+		List<Building> searchResults = findBuildings(query);
+
+		// 4. 즐겨찾기된 건물 리스트 + 일반 검색 결과 리스트 합치기
+		return mergeResults(bookmarkedBuildings, searchResults);
+	}
+
+	private Member findMemberById(String memberId) {
+		return memberRepository.findByMemberId(memberId)
 			.orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
-		List<Favorite> favorites = favoriteRepository.findByMember(member);
-		List<Long> bookmarkedBuildingIds = favorites.stream()
-			.map(favorite -> favorite.getBuilding().getId())
-			.toList();
+	}
 
-		// 3. 검색 결과와 즐겨찾기 여부 매핑
-		return buildings.stream()
-			.map(building -> new SearchSuggestionResponseDto(
-				building.getName(),
-				bookmarkedBuildingIds.contains(building.getId()) // 즐겨찾기 여부 확인
-			))
+	private List<Building> findBookmarkedBuildings(Member member, String query) {
+		return favoriteRepository.findByMember(member).stream()
+			.map(Favorite::getBuilding)
+			.filter(building -> building.getName().contains(query)) // 즐겨찾기 중 검색어 포함된 것 필터링
+			.toList();
+	}
+
+	private List<Building> findBuildings(String query) {
+		return buildingRepository.findTop6ByNameContainingOrderByNameAsc(query);
+	}
+
+	private List<SearchSuggestionResponseDto> mergeResults(List<Building> bookmarkedBuildings,
+		List<Building> searchResults) {
+		Set<Long> bookmarkedBuildingIds = bookmarkedBuildings.stream()
+			.map(Building::getId)
+			.collect(Collectors.toSet());
+
+		List<SearchSuggestionResponseDto> finalResults = new ArrayList<>();
+
+		// 즐겨찾기된 건물 먼저 추가
+		for (Building building : bookmarkedBuildings) {
+			finalResults.add(new SearchSuggestionResponseDto(building.getName(), true));
+		}
+
+		// 일반 검색 결과에서 중복되지 않는 건물 추가
+		for (Building building : searchResults) {
+			if (!bookmarkedBuildingIds.contains(building.getId())) {
+				finalResults.add(new SearchSuggestionResponseDto(building.getName(), false));
+			}
+		}
+
+		// 최대 6개만 반환
+		return finalResults.stream()
+			.limit(6)
 			.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [x]  코드 리팩토링
- [x]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [x]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`feature/search-suggestions` → `develop`

### 변경 사항

- **자동완성 검색어 추천 API 구현**

    - 사용자가 입력한 검색어가 포함된 단과대 리스트 반환
    - **즐겨찾기한 건물**이 있을 경우, 우선적으로 상단에 배치하여 반환
    - **최대 6개까지만 검색 결과 반환**
- **이전 명칭 및 별칭을 통한 검색 지원**
    - `building_aliases` 테이블 추가하여 건물 별칭을 관리
    - `IT대학`, `ICT대학` 등의 검색어 입력 시, `지능형 SW융합대학`이 추천되도록 개선
    - `BuildingAlias` 엔티티 및 `BuildingAliasRepository` 추가
    - `SearchSuggestionService`에서 공식 명칭 + 별칭을 함께 검색하도록 로직 개선

### 테스트 결과

- 자동완성 검색어 추천 정상 동작 확인
- 별칭을 활용한 검색 기능 정상 동작 확인 (`ICT대학` → `지능형 SW융합대학` 검색 가능)
- 즐겨찾기된 건물 우선 배치 확인

📌 **추후 Elasticsearch 적용 후 검색 최적화 예정!**