### PR TITLE
feat: 로그인 및 관리자 로그인 응답에 사용자 정보 포함

### DIFF
--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/TokenResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/TokenResponseDto.java
@@ -3,13 +3,15 @@ package com.YOGIITSU.dto.ResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class TokenResponseDto {
-
 	private String grantType;
 	private String accessToken;
 	private String refreshToken;
+	private UserResponseDto user;
 }

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/UserResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/UserResponseDto.java
@@ -1,0 +1,14 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class UserResponseDto {
+	private String id;
+	private String username;
+	private String email;
+}

--- a/src/main/java/com/YOGIITSU/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/YOGIITSU/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.YOGIITSU.jwt;
 
 import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
+import com.YOGIITSU.dto.ResponseDto.UserResponseDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -66,6 +67,7 @@ public class JwtTokenProvider {
 			.grantType("Bearer") // 인증 타입 (JWT 기본값)
 			.accessToken(accessToken)
 			.refreshToken(refreshToken)
+			.user(UserResponseDto.builder().build())
 			.build();
 	}
 

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -5,6 +5,8 @@ import com.YOGIITSU.config.handler.GlobalExceptionHandler.MemberNotFoundExceptio
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.PasswordMismatchException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.PasswordNotEqualsException;
 import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
+import com.YOGIITSU.dto.ResponseDto.UserResponseDto;
+import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import com.YOGIITSU.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.YOGIITSU.entity.Member;
 
 @Service
 @Transactional(readOnly = true)
@@ -40,16 +41,35 @@ public class MemberService {
 	@Transactional
 	public TokenResponseDto login(String memberId, String password) {
 		// 1. 아이디와 비밀번호를 기반으로 Authentication 객체 생성
-		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-			memberId, password);
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(memberId, password);
 
 		try {
 			// 2. 실제 검증 (사용자 비밀번호 체크)이 이루어지는 부분
 			Authentication authentication = authenticationManagerBuilder.getObject()
 				.authenticate(authenticationToken);
 
-			// 3. 인증 정보를 기반으로 JWT 토큰 생성
-			return jwtTokenProvider.generateToken(authentication);
+			// 3. 토큰 생성
+			TokenResponseDto tokenInfo = jwtTokenProvider.generateToken(authentication);
+
+			// 4. 사용자 정보 조회
+			Member member = memberRepository.findByMemberId(memberId)
+				.orElseThrow(MemberNotFoundException::new);
+
+			// 5. 사용자 정보 DTO 생성
+			UserResponseDto userDto = UserResponseDto.builder()
+				.id(member.getMemberId())
+				.username(member.getUsername())
+				.email(member.getEmail())
+				.build();
+
+			// 6. 사용자 정보 포함해서 반환
+			return TokenResponseDto.builder()
+				.grantType("Bearer")
+				.accessToken(tokenInfo.getAccessToken())
+				.refreshToken(tokenInfo.getRefreshToken())
+				.user(userDto)
+				.build();
 
 		} catch (BadCredentialsException e) {
 			// 4. 인증 실패 시 예외 처리
@@ -76,13 +96,29 @@ public class MemberService {
 		}
 
 		// 3. 비밀번호 검증 후 토큰 발급
-		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-			memberId, password);
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(memberId, password);
 
 		Authentication authentication = authenticationManagerBuilder.getObject()
 			.authenticate(authenticationToken);
 
-		return jwtTokenProvider.generateToken(authentication);
+		// 4. 토큰 발급
+		TokenResponseDto tokenInfo = jwtTokenProvider.generateToken(authentication);
+
+		// 5. 관리자 정보 포함 DTO 생성
+		UserResponseDto userDto = UserResponseDto.builder()
+			.id(member.getMemberId())
+			.username(member.getUsername())
+			.email(member.getEmail())
+			.build();
+
+		// 6. 전체 반환
+		return TokenResponseDto.builder()
+			.grantType("Bearer")
+			.accessToken(tokenInfo.getAccessToken())
+			.refreshToken(tokenInfo.getRefreshToken())
+			.user(userDto)
+			.build();
 	}
 
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `feature/login` → `develop`

### 변경 사항

- 로그인 응답 DTO(`TokenResponseDto`)에 사용자 정보(`UserResponseDto`) 포함

- `MemberService.login()`과 `adminLogin()` 메서드 수정
  - 인증 성공 시 사용자 정보 조회 및 DTO 생성
  - 응답에 accessToken, refreshToken, user 정보 포함

### 테스트 결과
- Postman으로 로그인 시 사용자 정보가 응답에 포함되는 것 확인

- 관리자 로그인도 동일하게 적용됨