### PR TITLE
feat: 비밀번호 찾기 기능 구현

### DIFF
--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -63,6 +63,13 @@ public class GlobalExceptionHandler {
 		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
 	}
 
+	// 이메일 인증이 승인되지 않은 경우 예외 처리
+	@ExceptionHandler(EmailVerificationNotApprovedException.class)
+	public ResponseEntity<Map<String, String>> handleNotApproved(EmailVerificationNotApprovedException e) {
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+			.body(Map.of("message", e.getMessage()));
+	}
+
 	// 즐겨찾기 관련 예외 처리 추가
 	@ExceptionHandler(EntityNotFoundException.class)
 	public ResponseEntity<Map<String, String>> handleEntityNotFoundException(
@@ -143,6 +150,12 @@ public class GlobalExceptionHandler {
 
 		public PasswordNotEqualsException() {
 			super("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.");
+		}
+	}
+
+	public static class EmailVerificationNotApprovedException extends RuntimeException {
+		public EmailVerificationNotApprovedException() {
+			super("이메일 인증이 완료되지 않았습니다.");
 		}
 	}
 }

--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.YOGIITSU.dto.RequestDto.ChangePasswordRequestDto;
 import com.YOGIITSU.dto.RequestDto.MemberLoginRequestDto;
 import com.YOGIITSU.dto.RequestDto.FindMemberIdRequestDto;
 import com.YOGIITSU.dto.RequestDto.PasswordCheckRequestDto;
+import com.YOGIITSU.dto.RequestDto.PasswordResetRequestDto;
 import com.YOGIITSU.dto.ResponseDto.FindMemberIdResponseDto;
 import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
 import com.YOGIITSU.jwt.JwtTokenProvider;
@@ -142,6 +143,22 @@ public class MemberController {
 			requestDto.getConfirmPassword());
 
 		// 4. 성공 메시지 반환
+		return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
+	}
+
+	/**
+	 * 비밀번호 찾기 (재설정) - 로그인되지 않은 상태
+	 * 이메일 인증 완료 여부를 기반으로 비밀번호 재설정 허용
+	 *
+	 * @param requestDto 요청 데이터 (이메일, 새 비밀번호, 확인 비밀번호)
+	 * @return 비밀번호 재설정 결과
+	 */
+	@PostMapping("/find-password")
+	public ResponseEntity<Map<String, String>> resetPassword(
+		@RequestBody PasswordResetRequestDto requestDto) {
+
+		memberService.resetPasswordAfterEmailVerification(requestDto);
+
 		return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
 	}
 }

--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -123,7 +123,7 @@ public class MemberController {
 	 * @return 비밀번호 변경 결과
 	 */
 
-	@PostMapping("/change-password")
+	@PatchMapping("/change-password")
 	public ResponseEntity<Map<String, String>> changePassword(
 		@RequestBody ChangePasswordRequestDto requestDto, HttpServletRequest httpRequest) {
 

--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -11,6 +11,8 @@ import com.YOGIITSU.dto.ResponseDto.FindMemberIdResponseDto;
 import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import com.YOGIITSU.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.HashMap;
 import java.util.Map;
 
+@Tag(name = "회원 관련 API", description = "로그인, 아이디 찾기, 비밀번호 재설정, 탈퇴 등 회원 기능 제공")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -40,6 +43,7 @@ public class MemberController {
 	 * @param memberLoginRequestDto 요청 데이터 (아이디, 비밀번호)
 	 * @return TokenInfo JWT 토큰 정보
 	 */
+	@Operation(summary = "회원 로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
 	@PostMapping("/login")
 	public TokenResponseDto login(@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
 		return memberService.login(
@@ -54,6 +58,7 @@ public class MemberController {
 	 * @param memberLoginRequestDto 요청 데이터 (아이디, 비밀번호)
 	 * @return TokenInfo JWT 토큰 정보
 	 */
+	@Operation(summary = "관리자 로그인", description = "관리자 권한을 가진 계정으로 로그인합니다.")
 	@PostMapping("/admin/login")
 	public TokenResponseDto adminLogin(@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
 		return memberService.adminLogin(
@@ -68,6 +73,7 @@ public class MemberController {
 	 * @param request 요청 데이터 (이메일)
 	 * @return 아이디 찾기 결과
 	 */
+	@Operation(summary = "아이디 찾기", description = "이메일을 기반으로 등록된 아이디를 조회합니다.")
 	@PostMapping("/find-id")
 	public ResponseEntity<FindMemberIdResponseDto> findId(
 		@RequestBody FindMemberIdRequestDto request) {
@@ -88,6 +94,7 @@ public class MemberController {
 	 *
 	 * @param request HTTP 요청 객체
 	 */
+	@Operation(summary = "회원 탈퇴", description = "비밀번호 확인 후 JWT 토큰 기반으로 회원 탈퇴 처리합니다.")
 	@DeleteMapping("/delete")
 	public ResponseEntity<Map<String, String>> deleteMember(
 		@RequestBody PasswordCheckRequestDto request, HttpServletRequest httpRequest) {
@@ -123,7 +130,7 @@ public class MemberController {
 	 * @param httpRequest HTTP 요청 객체
 	 * @return 비밀번호 변경 결과
 	 */
-
+	@Operation(summary = "비밀번호 변경", description = "로그인된 상태에서 새 비밀번호로 변경합니다.")
 	@PatchMapping("/change-password")
 	public ResponseEntity<Map<String, String>> changePassword(
 		@RequestBody ChangePasswordRequestDto requestDto, HttpServletRequest httpRequest) {
@@ -147,12 +154,12 @@ public class MemberController {
 	}
 
 	/**
-	 * 비밀번호 찾기 (재설정) - 로그인되지 않은 상태
-	 * 이메일 인증 완료 여부를 기반으로 비밀번호 재설정 허용
+	 * 비밀번호 찾기 (재설정) 로그인되지 않은 상태 -> 이메일 인증 완료 여부를 기반으로 비밀번호 재설정 허용
 	 *
 	 * @param requestDto 요청 데이터 (이메일, 새 비밀번호, 확인 비밀번호)
 	 * @return 비밀번호 재설정 결과
 	 */
+	@Operation(summary = "비밀번호 찾기 (재설정)", description = "비밀번호를 찾기 위해 이메일 인증을 완료한 사용자가 비밀번호를 재설정합니다.")
 	@PostMapping("/find-password")
 	public ResponseEntity<Map<String, String>> resetPassword(
 		@RequestBody PasswordResetRequestDto requestDto) {

--- a/src/main/java/com/YOGIITSU/dto/RequestDto/PasswordResetRequestDto.java
+++ b/src/main/java/com/YOGIITSU/dto/RequestDto/PasswordResetRequestDto.java
@@ -1,0 +1,16 @@
+package com.YOGIITSU.dto.RequestDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequestDto {
+
+	private String email;
+	private String newPassword;
+	private String confirmPassword;
+
+}

--- a/src/main/java/com/YOGIITSU/repository/EmailMessageRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/EmailMessageRepository.java
@@ -19,4 +19,7 @@ public interface EmailMessageRepository extends JpaRepository<EmailMessage, Long
 	@Transactional
 	@Query("DELETE FROM EmailMessage e WHERE e.expiresAt < :now")
 	int deleteAllExpired(@Param("now") LocalDateTime now); //5분 만료된 코드 삭제
+
+	Optional<EmailMessage> findByEmail(String email);
+
 }

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -1,13 +1,17 @@
 package com.YOGIITSU.service;
 
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.AdminAccessDeniedException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.EmailVerificationNotApprovedException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.MemberNotFoundException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.PasswordMismatchException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.PasswordNotEqualsException;
+import com.YOGIITSU.dto.RequestDto.PasswordResetRequestDto;
 import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
 import com.YOGIITSU.dto.ResponseDto.UserResponseDto;
+import com.YOGIITSU.entity.EmailMessage;
 import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.jwt.JwtTokenProvider;
+import com.YOGIITSU.repository.EmailMessageRepository;
 import com.YOGIITSU.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -29,6 +33,7 @@ public class MemberService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final EmailMessageRepository emailMessageRepository;
 	private final Logger logger = LoggerFactory.getLogger(MemberService.class);
 
 	/**
@@ -188,5 +193,40 @@ public class MemberService {
 
 		// 4. 저장
 		memberRepository.save(member);
+	}
+
+	/**
+	 * 비밀번호 재설정 메서드 (이메일 인증 후)
+	 *
+	 * @param requestDto 비밀번호 재설정 요청 DTO
+	 */
+	@Transactional
+	public void resetPasswordAfterEmailVerification(PasswordResetRequestDto requestDto) {
+
+		// 1. 이메일로 인증 요청 내역 조회 (없으면 예외 발생)
+		EmailMessage emailMessage = emailMessageRepository.findByEmail(requestDto.getEmail())
+			.orElseThrow(EmailVerificationNotApprovedException::new);
+
+		// 2. 이메일 인증이 완료되지 않은 경우 예외 발생
+		if (emailMessage.getIsApproved() == null || !emailMessage.getIsApproved()) {
+			throw new EmailVerificationNotApprovedException();
+		}
+
+		// 3. 새 비밀번호와 비밀번호 확인이 일치하지 않으면 예외 발생
+		if (!requestDto.getNewPassword().equals(requestDto.getConfirmPassword())) {
+			throw new PasswordMismatchException();
+		}
+
+		// 4. 이메일로 사용자 조회 (없으면 예외 발생)
+		Member member = memberRepository.findByEmail(requestDto.getEmail())
+			.orElseThrow(MemberNotFoundException::new);
+
+		// 5. 비밀번호 암호화 후 변경
+		member.changePassword(passwordEncoder.encode(requestDto.getNewPassword()));
+		memberRepository.save(member);
+
+		// 6. 인증 상태 초기화 (다시 사용하지 못하게)
+		emailMessage.setIsApproved(false);
+		emailMessageRepository.save(emailMessage);
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 문서 수정
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `feature/find-password` → `develop`

### 변경 사항

- 이메일 인증 기반 비밀번호 찾기 (재설정) API 구현

    - 인증된 이메일에 대해서만 비밀번호 재설정 가능하도록 로직 구성
    
    - 이메일 인증 여부 (`isApproved`) 확인 후 비밀번호 변경 처리
    - 인증 완료 후 `isApproved` 값 `false`로 초기화하여 재사용 방지
    
- 비밀번호 변경/찾기 관련 예외 처리 추가
    - 이메일 인증되지 않은 경우 `EmailVerificationNotApprovedException`
    - 존재하지 않는 이메일인 경우 `MemberNotFoundException`
    - 비밀번호 불일치 시 `PasswordMismatchException`
    
- Swagger 문서화 추가
    - `/members/find-password`, `/members/change-password` 등 API 설명 및 summary 작성
- 비밀번호 변경 API HTTP 메서드 수정
    - POST → PATCH로 변경하여 RESTful 원칙 준수

### 테스트 결과

- ✅ 이메일 인증이 완료되지 않은 상태에서 비밀번호 재설정 요청 시 `401 UNAUTHORIZED` 반환 확인

- ✅ 잘못된 비밀번호 입력 시 예외 메시지 정상 반환

- ✅ 이메일 인증 완료된 경우에만 정상적으로 비밀번호 재설정 처리

- ✅ Swagger 문서에서 API 확인 가능