### PR TITLE
refactor: 이메일 인증 로직 구조 개선 

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/EmailController.java
+++ b/src/main/java/com/YOGIITSU/controller/EmailController.java
@@ -5,6 +5,7 @@ import com.YOGIITSU.dto.ResponseDto.EmailPostResponseDto;
 import com.YOGIITSU.entity.EmailMessage;
 import com.YOGIITSU.jwt.EmailVerificationJwtProvider;
 import com.YOGIITSU.service.EmailService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +25,7 @@ public class EmailController {
 	 * @return ResponseEntity<EmailResponseDto>
 	 */
 	@PostMapping("/email")
-	public ResponseEntity<EmailPostResponseDto> sendJoinMail(@RequestBody EmailPostRequestDto emailPostRequestDto) {
+	public ResponseEntity<EmailPostResponseDto> sendJoinMail(@RequestBody @Valid EmailPostRequestDto emailPostRequestDto) {
 		// EmailMessage 객체 생성
 		EmailMessage emailMessage = EmailMessage.builder()
 			.email(emailPostRequestDto.getEmail()) // 수신자 이메일

--- a/src/main/java/com/YOGIITSU/controller/EmailController.java
+++ b/src/main/java/com/YOGIITSU/controller/EmailController.java
@@ -5,11 +5,14 @@ import com.YOGIITSU.dto.ResponseDto.EmailPostResponseDto;
 import com.YOGIITSU.entity.EmailMessage;
 import com.YOGIITSU.jwt.EmailVerificationJwtProvider;
 import com.YOGIITSU.service.EmailService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "인증 코드 전송 API", description = "인증 메일 전송 기능 제공합니다.")
 @RestController
 @RequestMapping("/send-mail")
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ public class EmailController {
 	 * @param emailPostRequestDto 이메일 요청 DTO
 	 * @return ResponseEntity<EmailResponseDto>
 	 */
+	@Operation(summary = "회원가입 인증 메일 전송", description = "입력한 이메일로 인증 코드를 전송하고, 이메일 + 인증코드를 포함한 토큰을 반환합니다.")
 	@PostMapping("/email")
 	public ResponseEntity<EmailPostResponseDto> sendJoinMail(@RequestBody @Valid EmailPostRequestDto emailPostRequestDto) {
 		// EmailMessage 객체 생성

--- a/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
+++ b/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
@@ -6,74 +6,81 @@ import com.YOGIITSU.entity.EmailMessage;
 import com.YOGIITSU.jwt.EmailVerificationJwtProvider;
 import com.YOGIITSU.repository.EmailMessageRepository;
 import io.jsonwebtoken.Claims;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "이메일 인증 코드 검증 API", description = "인증 코드 검증 기능 제공합니다.")
 @RestController
 @RequestMapping("/verify")
 @RequiredArgsConstructor
 public class EmailVerificationController {
 
-	private final EmailVerificationJwtProvider emailJwtProvider;
-	private final EmailMessageRepository emailMessageRepository;
+    private final EmailVerificationJwtProvider emailJwtProvider;
+    private final EmailMessageRepository emailMessageRepository;
 
-	@PostMapping("/code")
-	public ResponseEntity<EmailVerificationResponseDto> verifyCode(
-		@RequestHeader("X-Email-Verification-Token") String token, // 커스텀 헤더로 변경
-		@RequestBody EmailVerificationRequestDto request) {
+    @Operation(
+        summary = "이메일 인증 코드 검증",
+        description = "사용자가 입력한 인증 코드를 토큰에 포함된 코드와 비교하고, 인증 성공 시 DB의 승인 상태를 true로 변경합니다."
+    )
+    @PostMapping("/code")
+    public ResponseEntity<EmailVerificationResponseDto> verifyCode(
+        @RequestHeader("X-Email-Verification-Token") String token, // 커스텀 헤더로 변경
+        @RequestBody EmailVerificationRequestDto request) {
 
-		try {
-			// 1. JWT 토큰에서 이메일과 인증 코드 가져오기
-			Claims claims = emailJwtProvider.parseEmailToken(token)
-				.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 토큰입니다."));
+        try {
+            // 1. JWT 토큰에서 이메일과 인증 코드 가져오기
+            Claims claims = emailJwtProvider.parseEmailToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 토큰입니다."));
 
-			String storedEmail = claims.getSubject(); // 이메일 정보
-			String storedCode = claims.get("code", String.class); // 저장된 인증 코드
+            String storedEmail = claims.getSubject(); // 이메일 정보
+            String storedCode = claims.get("code", String.class); // 저장된 인증 코드
 
-			// 2. 사용자가 입력한 코드와 JWT 내부 코드 비교
-			if (!request.getCode().equals(storedCode)) {
-				return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-					.body(EmailVerificationResponseDto.builder()
-						.status("error")
-						.message("인증 실패: 잘못된 인증 코드입니다.")
-						.email(null)
-						.build());
-			}
+            // 2. 사용자가 입력한 코드와 JWT 내부 코드 비교
+            if (!request.getCode().equals(storedCode)) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(EmailVerificationResponseDto.builder()
+                        .status("error")
+                        .message("인증 실패: 잘못된 인증 코드입니다.")
+                        .email(null)
+                        .build());
+            }
 
-			// 3. DB에서 해당 이메일과 코드가 있는지 확인
-			Optional<EmailMessage> emailMessageOptional = emailMessageRepository.findByEmailAndCode(
-				storedEmail, storedCode);
-			if (emailMessageOptional.isEmpty()) {
-				return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-					.body(EmailVerificationResponseDto.builder()
-						.status("error")
-						.message("인증 실패: DB에서 해당 이메일과 인증 코드를 찾을 수 없습니다.")
-						.email(null)
-						.build());
-			}
+            // 3. DB에서 해당 이메일과 코드가 있는지 확인
+            Optional<EmailMessage> emailMessageOptional = emailMessageRepository.findByEmailAndCode(
+                storedEmail, storedCode);
+            if (emailMessageOptional.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(EmailVerificationResponseDto.builder()
+                        .status("error")
+                        .message("인증 실패: DB에서 해당 이메일과 인증 코드를 찾을 수 없습니다.")
+                        .email(null)
+                        .build());
+            }
 
-			// 4. 인증 성공 → is_approved = true로 변경
-			EmailMessage emailMessage = emailMessageOptional.get();
-			emailMessage.setIsApproved(true);
-			emailMessageRepository.save(emailMessage);
+            // 4. 인증 성공 → is_approved = true로 변경
+            EmailMessage emailMessage = emailMessageOptional.get();
+            emailMessage.setIsApproved(true);
+            emailMessageRepository.save(emailMessage);
 
-			// 5. 인증 성공 응답
-			return ResponseEntity.ok(EmailVerificationResponseDto.builder()
-				.status("success")
-				.message("이메일 인증이 완료되었습니다. 회원가입을 진행하세요.")
-				.email(storedEmail)
-				.build());
+            // 5. 인증 성공 응답
+            return ResponseEntity.ok(EmailVerificationResponseDto.builder()
+                .status("success")
+                .message("이메일 인증이 완료되었습니다. 회원가입을 진행하세요.")
+                .email(storedEmail)
+                .build());
 
-		} catch (IllegalArgumentException e) {
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-				.body(EmailVerificationResponseDto.builder()
-					.status("error")
-					.message("인증 실패: " + e.getMessage())
-					.email(null)
-					.build());
-		}
-	}
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(EmailVerificationResponseDto.builder()
+                    .status("error")
+                    .message("인증 실패: " + e.getMessage())
+                    .email(null)
+                    .build());
+        }
+    }
 }

--- a/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
+++ b/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
@@ -8,7 +8,6 @@ import com.YOGIITSU.repository.EmailMessageRepository;
 import io.jsonwebtoken.Claims;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,43 +22,28 @@ public class EmailVerificationController {
 
 	@PostMapping("/code")
 	public ResponseEntity<EmailVerificationResponseDto> verifyCode(
-		@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader, // JWT 토큰 받기
+		@RequestHeader("X-Email-Verification-Token") String token, // 커스텀 헤더로 변경
 		@RequestBody EmailVerificationRequestDto request) {
 
 		try {
-			// 1. Authorization 헤더에서 Bearer 토큰 추출
-			if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-				return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-					.body(EmailVerificationResponseDto.builder()
-						.status("error")
-						.message("인증 실패: 인증 토큰이 없습니다.")
-						.email(null)
-						.token(null)
-						.code(null)
-						.build());
-			}
-			String token = authorizationHeader.substring(7); // "Bearer " 제거 후 순수 토큰 값 추출
-
-			// 2. JWT 토큰에서 이메일과 인증 코드 가져오기
+			// 1. JWT 토큰에서 이메일과 인증 코드 가져오기
 			Claims claims = emailJwtProvider.parseEmailToken(token)
 				.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 토큰입니다."));
 
 			String storedEmail = claims.getSubject(); // 이메일 정보
 			String storedCode = claims.get("code", String.class); // 저장된 인증 코드
 
-			// 3. 사용자가 입력한 코드와 JWT 내부 코드 비교
+			// 2. 사용자가 입력한 코드와 JWT 내부 코드 비교
 			if (!request.getCode().equals(storedCode)) {
 				return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
 					.body(EmailVerificationResponseDto.builder()
 						.status("error")
 						.message("인증 실패: 잘못된 인증 코드입니다.")
 						.email(null)
-						.token(null)
-						.code(null)
 						.build());
 			}
 
-			// ✅ 4. DB에서 해당 이메일과 코드가 있는지 확인
+			// 3. DB에서 해당 이메일과 코드가 있는지 확인
 			Optional<EmailMessage> emailMessageOptional = emailMessageRepository.findByEmailAndCode(
 				storedEmail, storedCode);
 			if (emailMessageOptional.isEmpty()) {
@@ -68,23 +52,19 @@ public class EmailVerificationController {
 						.status("error")
 						.message("인증 실패: DB에서 해당 이메일과 인증 코드를 찾을 수 없습니다.")
 						.email(null)
-						.token(null)
-						.code(null)
 						.build());
 			}
 
-			// ✅ 5. 인증 성공 → is_approved = 1로 업데이트
+			// 4. 인증 성공 → is_approved = true로 변경
 			EmailMessage emailMessage = emailMessageOptional.get();
-			emailMessage.setIsApproved(true); // 승인 상태 변경
-			emailMessageRepository.save(emailMessage); // ✅ DB 업데이트
+			emailMessage.setIsApproved(true);
+			emailMessageRepository.save(emailMessage);
 
-			// ✅ 6. 인증 성공 응답
+			// 5. 인증 성공 응답
 			return ResponseEntity.ok(EmailVerificationResponseDto.builder()
 				.status("success")
 				.message("이메일 인증이 완료되었습니다. 회원가입을 진행하세요.")
 				.email(storedEmail)
-				.token(null)
-				.code(null)
 				.build());
 
 		} catch (IllegalArgumentException e) {
@@ -93,8 +73,6 @@ public class EmailVerificationController {
 					.status("error")
 					.message("인증 실패: " + e.getMessage())
 					.email(null)
-					.token(null)
-					.code(null)
 					.build());
 		}
 	}

--- a/src/main/java/com/YOGIITSU/dto/RequestDto/EmailVerificationRequestDto.java
+++ b/src/main/java/com/YOGIITSU/dto/RequestDto/EmailVerificationRequestDto.java
@@ -8,7 +8,5 @@ import lombok.*;
 @NoArgsConstructor
 public class EmailVerificationRequestDto {
 
-	private String email;
-	private String token;
-	private String code;
+    private String code;
 }

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/EmailVerificationResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/EmailVerificationResponseDto.java
@@ -14,6 +14,4 @@ public class EmailVerificationResponseDto {
 	private String status; // 응답 상태 (success, error)
 	private String message; // 응답 메시지
 	private String email; // 인증한 이메일
-	private String token; // 토큰 (성공 시 null)
-	private String code; // 인증 코드 (성공 시 null)
 }

--- a/src/main/java/com/YOGIITSU/service/EmailService.java
+++ b/src/main/java/com/YOGIITSU/service/EmailService.java
@@ -35,6 +35,11 @@ public class EmailService {
 		String authNum = createCode(); // 인증 코드 생성
 		String email = emailMessage.getEmail();
 
+		// 이메일 도메인 검사 추가
+		if (!isAllowedEmailDomain(email)) {
+			throw new IllegalArgumentException("suwon.ac.kr, naver.com, gmail.com 도메인만 인증할 수 있습니다.");
+		}
+
 		try {
 			// 항상 새로 저장되도록
 			EmailMessage newMessage = EmailMessage.builder()
@@ -59,6 +64,12 @@ public class EmailService {
 		}
 	}
 
+	//도메인 검사 메서드 추가
+	private boolean isAllowedEmailDomain(String email) {
+		return email.endsWith("@suwon.ac.kr")
+			|| email.endsWith("@naver.com")
+			|| email.endsWith("@gmail.com");
+	}
 
 	/**
 	 * MimeMessage 생성 메서드 (Spring Mail API)
@@ -86,7 +97,7 @@ public class EmailService {
 	private String createCode() {
 		Random random = new Random();
 		StringBuilder key = new StringBuilder();
-		for (int i = 0; i < 8; i++) {
+		for (int i = 0; i < 6; i++) {
 			key.append((char) (random.nextInt(26) + 65)); // A~Z (대문자)
 		}
 		return key.toString();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/email-verification` → `develop`

### 변경 사항

- **이메일 인증 코드 생성 방식 변경**
    - 인증 코드를 8자리 → **6자리 대문자 알파벳**으로 축소

- **허용 이메일 도메인 제한 로직 추가**
    - `@suwon.ac.kr`, `@naver.com`, `@gmail.com` 외 도메인 차단

- **인증 코드 토큰 전달 방식 개선**
    - 기존 `Authorization` 헤더 사용 방식 제거
    - **커스텀 헤더 `X-Email-Verification-Token`** 사용으로 로그인 토큰과 분리

- **DTO 및 응답 구조 리팩토링**
    - `EmailVerificationRequestDto`에서 `token`, `email` 필드 제거 → `code`만 사용
    - `EmailVerificationResponseDto`에서 `token`, `code` 제거 → 필요한 정보만 응답

- **기타 리팩토링**
    - `@Valid` 추가하여 이메일 형식 유효성 검사 적용
    - 불필요한 주석 정리 및 메서드 분리

### 테스트 결과

- **도메인 필터링 확인**
    - `@kakao.com` 등 허용되지 않은 도메인 사용 시 인증 실패 응답 반환

- **이메일 인증 요청/검증 정상 작동**
    - 6자리 인증 코드 생성 및 이메일 발송 확인
    - JWT에 담긴 인증 코드와 입력 코드 일치 시 인증 성공 및 DB `is_approved = true` 확인

- **에러 응답 확인**
    - 잘못된 코드 입력 시 `"잘못된 인증 코드입니다."` 메시지 반환
    - 만료 코드 사용 시 `"DB에서 해당 이메일과 인증 코드를 찾을 수 없습니다."` 메시지 반환

- **기존 스케줄러 로직 정상 동작 확인**
    - 만료된 인증 코드가 5분 후 자동 삭제되는 것 확인
