### PR TITLE
feat: role 기반 로그인 API 통합 및 관리자 로그인 API 제거

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -43,25 +43,10 @@ public class MemberController {
 	 * @param memberLoginRequestDto 요청 데이터 (아이디, 비밀번호)
 	 * @return TokenInfo JWT 토큰 정보
 	 */
-	@Operation(summary = "회원 로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
+	@Operation(summary = "로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
 	@PostMapping("/login")
 	public TokenResponseDto login(@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
 		return memberService.login(
-			memberLoginRequestDto.getMemberId(),
-			memberLoginRequestDto.getPassword()
-		);
-	}
-
-	/**
-	 * 관리자 로그인 API
-	 *
-	 * @param memberLoginRequestDto 요청 데이터 (아이디, 비밀번호)
-	 * @return TokenInfo JWT 토큰 정보
-	 */
-	@Operation(summary = "관리자 로그인", description = "관리자 권한을 가진 계정으로 로그인합니다.")
-	@PostMapping("/admin/login")
-	public TokenResponseDto adminLogin(@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
-		return memberService.adminLogin(
 			memberLoginRequestDto.getMemberId(),
 			memberLoginRequestDto.getPassword()
 		);

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/UserResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/UserResponseDto.java
@@ -11,4 +11,5 @@ public class UserResponseDto {
 	private String id;
 	private String username;
 	private String email;
+	private String role;
 }

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -41,7 +41,7 @@ public class MemberService {
 	 *
 	 * @param memberId 사용자의 아이디
 	 * @param password 사용자의 비밀번호
-	 * @return TokenInfo JWT 토큰 정보
+	 * @return TokenResponse JWT 토큰 정보
 	 */
 	@Transactional
 	public TokenResponseDto login(String memberId, String password) {
@@ -66,6 +66,7 @@ public class MemberService {
 				.id(member.getMemberId())
 				.username(member.getUsername())
 				.email(member.getEmail())
+				.role(member.getRole()) // role 추가
 				.build();
 
 			// 6. 사용자 정보 포함해서 반환
@@ -81,51 +82,6 @@ public class MemberService {
 			throw new RuntimeException("아이디 또는 비밀번호가 잘못되었습니다", e);
 		}
 	}
-
-	/**
-	 * 관리자 로그인 처리 메서드
-	 *
-	 * @param memberId 사용자의 아이디
-	 * @param password 사용자의 비밀번호
-	 * @return TokenInfo JWT 토큰 정보
-	 */
-	@Transactional
-	public TokenResponseDto adminLogin(String memberId, String password) {
-		// 1. 사용자가 존재하는지 확인
-		Member member = memberRepository.findByMemberId(memberId)
-			.orElseThrow(MemberNotFoundException::new);
-
-		// 2. 관리자 계정인지 확인
-		if (!"ADMIN".equals(member.getRole())) {
-			throw new AdminAccessDeniedException();
-		}
-
-		// 3. 비밀번호 검증 후 토큰 발급
-		UsernamePasswordAuthenticationToken authenticationToken =
-			new UsernamePasswordAuthenticationToken(memberId, password);
-
-		Authentication authentication = authenticationManagerBuilder.getObject()
-			.authenticate(authenticationToken);
-
-		// 4. 토큰 발급
-		TokenResponseDto tokenInfo = jwtTokenProvider.generateToken(authentication);
-
-		// 5. 관리자 정보 포함 DTO 생성
-		UserResponseDto userDto = UserResponseDto.builder()
-			.id(member.getMemberId())
-			.username(member.getUsername())
-			.email(member.getEmail())
-			.build();
-
-		// 6. 전체 반환
-		return TokenResponseDto.builder()
-			.grantType("Bearer")
-			.accessToken(tokenInfo.getAccessToken())
-			.refreshToken(tokenInfo.getRefreshToken())
-			.user(userDto)
-			.build();
-	}
-
 
 	/**
 	 * 이메일로 아이디 찾기


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x]  기능 추가
- [x]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [x]  코드 리팩토링
- [x]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트


### 반영 브랜치

- `feature/login` → `develop`


### 변경 사항

- 기존의 일반 로그인 API와 관리자 로그인 API(`/admin/login`)를 하나의 API(`/login`)로 통합

- 사용자의 `role` 정보를 응답 DTO에 포함하여 관리자 여부를 확인 가능하게 함

- `adminLogin()` 서비스 로직 및 컨트롤러 API 삭제

- `UserResponseDto`에 `role` 필드 추가


### 테스트 결과

- ✅ 일반 사용자 로그인 시 `role: USER` 정상 반환 확인

- ✅ 관리자 계정 로그인 시 `role: ADMIN` 정상 반환 확인