### PR TITLE
fix: 이메일 인증 코드 저장 책임 분리 및 전송 흐름 개선

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/EmailController.java
+++ b/src/main/java/com/YOGIITSU/controller/EmailController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.time.LocalDateTime;
 
 @Tag(name = "인증 코드 전송 API", description = "인증 메일 전송 기능 제공합니다.")
 @RestController
@@ -18,39 +19,49 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class EmailController {
 
-	private final EmailService emailService;
-	private final EmailVerificationJwtProvider emailJwtProvider;
+    private final EmailService emailService;
+    private final EmailVerificationJwtProvider emailJwtProvider;
 
-	/**
-	 * 회원가입 이메일 인증 코드 전송
-	 *
-	 * @param emailPostRequestDto 이메일 요청 DTO
-	 * @return ResponseEntity<EmailResponseDto>
-	 */
-	@Operation(summary = "회원가입 인증 메일 전송", description = "입력한 이메일로 인증 코드를 전송하고, 이메일 + 인증코드를 포함한 토큰을 반환합니다.")
-	@PostMapping("/email")
-	public ResponseEntity<EmailPostResponseDto> sendJoinMail(@RequestBody @Valid EmailPostRequestDto emailPostRequestDto) {
-		// EmailMessage 객체 생성
-		EmailMessage emailMessage = EmailMessage.builder()
-			.email(emailPostRequestDto.getEmail()) // 수신자 이메일
-			.code("") // 인증 코드 생성 로직에서 설정됨
-			.isApproved(false) // 초기 승인 상태
-			.build();
+    /**
+     * 회원가입 이메일 인증 코드 전송
+     *
+     * @param emailPostRequestDto 이메일 요청 DTO
+     * @return ResponseEntity<EmailResponseDto>
+     */
+    @Operation(summary = "회원가입 인증 메일 전송", description = "입력한 이메일로 인증 코드를 전송하고, 이메일 + 인증코드를 포함한 토큰을 반환합니다.")
+    @PostMapping("/email")
+    public ResponseEntity<EmailPostResponseDto> sendJoinMail(
+        @RequestBody @Valid EmailPostRequestDto emailPostRequestDto) {
+        String email = emailPostRequestDto.getEmail();
 
-		// 인증 코드 생성 및 이메일 발송
-		String code = emailService.sendMail(emailMessage, "email");
+        // 1. 인증 코드 생성
+        String code = emailService.generateVerificationCode();
 
-		// JWT 토큰 생성 (이메일 + 인증 코드 포함)
-		String token = emailJwtProvider.generateEmailToken(emailPostRequestDto.getEmail(), code);
+        // 2. EmailMessage 생성
+        EmailMessage emailMessage = EmailMessage.builder()
+            .email(email)
+            .code(code)
+            .isApproved(false)
+            .expiresAt(LocalDateTime.now().plusMinutes(5))
+            .build();
 
-		// JSON 형식 응답 반환
-		EmailPostResponseDto emailPostResponseDto = EmailPostResponseDto.builder()
-			.status("success")
-			.message("이메일 인증 코드가 발송되었습니다.")
-			.code(code)
-			.token(token)
-			.build();
+        // 3. DB에 저장
+        emailService.saveEmailMessage(emailMessage);
 
-		return ResponseEntity.ok(emailPostResponseDto);
-	}
+        // 4. 메일 전송
+        emailService.sendMail(emailMessage, "email");
+
+        // 5. 토큰 생성
+        String token = emailJwtProvider.generateEmailToken(email, code);
+
+        // 6. 응답
+        EmailPostResponseDto response = EmailPostResponseDto.builder()
+            .status("success")
+            .message("이메일 인증 코드가 발송되었습니다.")
+            .code(code)
+            .token(token)
+            .build();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/YOGIITSU/service/EmailService.java
+++ b/src/main/java/com/YOGIITSU/service/EmailService.java
@@ -2,7 +2,7 @@ package com.YOGIITSU.service;
 
 import com.YOGIITSU.entity.EmailMessage;
 import com.YOGIITSU.repository.EmailMessageRepository;
-import java.time.LocalDateTime;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
@@ -12,107 +12,92 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Random;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailService {
 
-	private final JavaMailSender javaMailSender;
-	private final SpringTemplateEngine templateEngine;
-	private final EmailMessageRepository emailMessageRepository;
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+    private final EmailMessageRepository emailMessageRepository;
 
-	/**
-	 * 이메일 전송 메서드
-	 *
-	 * @param emailMessage 이메일 메시지 객체
-	 * @param type         이메일 타입 (e.g., "password", "verification")
-	 * @return 인증 코드
-	 */
-	@Transactional
-	public String sendMail(EmailMessage emailMessage, String type) {
-		String authNum = createCode(); // 인증 코드 생성
-		String email = emailMessage.getEmail();
+    /**
+     * 인증 코드 생성 (6자리 대문자)
+     */
+    public String generateVerificationCode() {
+        Random random = new Random();
+        StringBuilder key = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            key.append((char) (random.nextInt(26) + 65)); // A~Z
+        }
+        return key.toString();
+    }
 
-		// 이메일 도메인 검사 추가
-		if (!isAllowedEmailDomain(email)) {
-			throw new IllegalArgumentException("suwon.ac.kr, naver.com, gmail.com 도메인만 인증할 수 있습니다.");
-		}
+    /**
+     * 이메일 인증 메시지 저장
+     */
+    @Transactional
+    public void saveEmailMessage(EmailMessage emailMessage) {
+        emailMessageRepository.save(emailMessage);
+    }
 
-		try {
-			// 항상 새로 저장되도록
-			EmailMessage newMessage = EmailMessage.builder()
-				.email(email)
-				.code(authNum)
-				.isApproved(false)
-				.expiresAt(LocalDateTime.now().plusMinutes(5)) // 5분 유효
-				.build();
+    /**
+     * 이메일 전송 (코드 포함)
+     */
+    public void sendMail(EmailMessage emailMessage, String type) {
+        // 도메인 제한 체크
+        if (!isAllowedEmailDomain(emailMessage.getEmail())) {
+            throw new IllegalArgumentException(
+                "suwon.ac.kr, naver.com, gmail.com 도메인만 인증할 수 있습니다.");
+        }
 
-			emailMessageRepository.save(newMessage);
+        try {
+            MimeMessageHelper mimeMessageHelper = createMimeMessage(emailMessage,
+                emailMessage.getCode(), type);
+            javaMailSender.send(mimeMessageHelper.getMimeMessage());
+            log.info("메일 전송 성공: {}", emailMessage.getEmail());
 
-			// 이메일 전송
-			MimeMessageHelper mimeMessageHelper = createMimeMessage(emailMessage, authNum, type);
-			javaMailSender.send(mimeMessageHelper.getMimeMessage());
+        } catch (MailException e) {
+            log.error("메일 전송 실패: {}", e.getMessage());
+            throw new RuntimeException("메일 전송 중 오류가 발생했습니다: " + e.getMessage(), e);
+        }
+    }
 
-			log.info("메일 전송 성공: {}", email);
-			return authNum;
+    /**
+     * 허용된 이메일 도메인인지 확인
+     */
+    private boolean isAllowedEmailDomain(String email) {
+        return email.endsWith("@suwon.ac.kr")
+            || email.endsWith("@naver.com")
+            || email.endsWith("@gmail.com");
+    }
 
-		} catch (MailException e) {
-			log.error("메일 전송 실패: {}", e.getMessage());
-			throw new RuntimeException("메일 전송 중 오류가 발생했습니다: " + e.getMessage(), e);
-		}
-	}
+    /**
+     * MimeMessage 생성
+     */
+    private MimeMessageHelper createMimeMessage(EmailMessage emailMessage, String authNum,
+        String type) {
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(
+                javaMailSender.createMimeMessage(), false, "UTF-8");
 
-	//도메인 검사 메서드 추가
-	private boolean isAllowedEmailDomain(String email) {
-		return email.endsWith("@suwon.ac.kr")
-			|| email.endsWith("@naver.com")
-			|| email.endsWith("@gmail.com");
-	}
+            mimeMessageHelper.setTo(emailMessage.getEmail());
+            mimeMessageHelper.setSubject("YOGIITSU 인증 코드: " + authNum);
+            mimeMessageHelper.setText(setContext(authNum, type), true);
 
-	/**
-	 * MimeMessage 생성 메서드 (Spring Mail API)
-	 */
-	private MimeMessageHelper createMimeMessage(EmailMessage emailMessage, String authNum,
-		String type) {
-		try {
-			MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(
-				javaMailSender.createMimeMessage(), false, "UTF-8");
-			mimeMessageHelper.setTo(emailMessage.getEmail()); // 수신자 이메일
-			mimeMessageHelper.setSubject("YOGIITSU 인증 코드: " + authNum); // 이메일 제목
-			mimeMessageHelper.setText(setContext(authNum, type), true); // HTML 본문 내용
+            return mimeMessageHelper;
+        } catch (Exception e) {
+            throw new RuntimeException("MimeMessage 생성 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
 
-			return mimeMessageHelper;
-		} catch (Exception e) {
-			throw new RuntimeException("MimeMessage 생성 중 오류 발생: " + e.getMessage(), e);
-		}
-	}
-
-	/**
-	 * 랜덤 인증번호 생성
-	 *
-	 * @return 생성된 인증번호 (8자리)
-	 */
-	private String createCode() {
-		Random random = new Random();
-		StringBuilder key = new StringBuilder();
-		for (int i = 0; i < 6; i++) {
-			key.append((char) (random.nextInt(26) + 65)); // A~Z (대문자)
-		}
-		return key.toString();
-	}
-
-	/**
-	 * Thymeleaf를 통해 이메일 본문 내용 생성
-	 *
-	 * @param code 인증 코드
-	 * @param type 템플릿 이름
-	 * @return HTML 본문 내용
-	 */
-	private String setContext(String code, String type) {
-		Context context = new Context();
-		context.setVariable("code", code);
-		return templateEngine.process(type, context);
-	}
+    /**
+     * HTML 메일 본문 생성 (Thymeleaf)
+     */
+    private String setContext(String code, String type) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process(type, context);
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/email-verification` → `develop`

### 변경 사항

- 이메일 인증 흐름에서 인증 코드 DB 저장과 전송 책임을 명확하게 분리

- 기존 sendMail() 메서드 내에 있던 저장 로직을 분리하여 saveEmailMessage()로 이동

- generateVerificationCode()를 통해 인증 코드 생성 책임도 별도 분리

- EmailController에서 순차적으로 코드 생성 → 저장 → 전송 → 토큰 생성 흐름을 명확하게 구성

- 인증 코드가 메일로는 전송되지만 DB에는 저장되지 않는 문제 해결

### 테스트 결과

- 로컬 Swagger에서 메일 전송 후 DB에 인증 코드가 정상 저장됨 확인
