### PR TITLE
fix: 회원가입 시 이메일 중복 및 인증 검증 순서 수정 및 전체 검증 로직 보완

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/SignUpController.java
+++ b/src/main/java/com/YOGIITSU/controller/SignUpController.java
@@ -5,7 +5,9 @@ import com.YOGIITSU.service.SignUpService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -26,8 +28,14 @@ public class SignUpController {
         description = "이메일 인증을 마친 사용자의 회원가입 정보를 등록합니다."
     )
     @PostMapping("/signup")
-    public Map<String, String> signUp(
+    public ResponseEntity<Map<String, String>> signUp(
         @RequestBody @Valid MemberSignUpRequestDto memberSignUpRequestDto) {
-        return signUpService.register(memberSignUpRequestDto);
+
+        signUpService.register(memberSignUpRequestDto);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "회원가입이 성공적으로 완료되었습니다.");
+        return ResponseEntity.ok(response);
     }
+
 }

--- a/src/main/java/com/YOGIITSU/repository/EmailMessageRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/EmailMessageRepository.java
@@ -13,13 +13,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public interface EmailMessageRepository extends JpaRepository<EmailMessage, Long> {
 
-	Optional<EmailMessage> findByEmailAndCode(String email, String code);
+    Optional<EmailMessage> findByEmailAndCode(String email, String code);
 
-	@Modifying
-	@Transactional
-	@Query("DELETE FROM EmailMessage e WHERE e.expiresAt < :now")
-	int deleteAllExpired(@Param("now") LocalDateTime now); //5분 만료된 코드 삭제
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM EmailMessage e WHERE e.expiresAt < :now")
+    int deleteAllExpired(@Param("now") LocalDateTime now); //5분 만료된 코드 삭제
 
-	Optional<EmailMessage> findByEmail(String email);
+    Optional<EmailMessage> findByEmail(String email);
+
+    Optional<EmailMessage> findByEmailAndIsApprovedTrue(String email);
 
 }

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -24,21 +24,21 @@ public class SignUpService {
     @Transactional
     public void register(MemberSignUpRequestDto dto) {
 
-        // 1. 이메일 인증 확인
+        // 1. 이메일 중복 체크
+        if (memberRepository.findByEmail(dto.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("해당 이메일로 가입한 내역이 있습니다.");
+        }
+
+        // 2. 이메일 인증 확인
         Optional<EmailMessage> verifiedEmail = emailMessageRepository.findByEmailAndIsApprovedTrue(
             dto.getEmail());
         if (verifiedEmail.isEmpty()) {
             throw new IllegalArgumentException("이메일 인증이 완료되지 않았습니다.");
         }
 
-        // 2. 아이디 중복 체크
+        // 3. 아이디 중복 체크
         if (memberRepository.findByMemberId(dto.getMemberId()).isPresent()) {
             throw new IllegalArgumentException("아이디가 이미 존재합니다.");
-        }
-
-        // 3. 이메일 중복 체크
-        if (memberRepository.findByEmail(dto.getEmail()).isPresent()) {
-            throw new IllegalArgumentException("해당 이메일로 가입한 내역이 있습니다.");
         }
 
         // 4. 이메일 도메인 검사

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -77,16 +77,19 @@ public class SignUpService {
 
     private void validatePassword(String password) {
         if (password.length() < 8) {
-            throw new IllegalArgumentException("비밀번호는 최소 8글자여야 합니다.");
+            throw new IllegalArgumentException("비밀번호는 최소 8자 이상이어야 합니다.");
         }
-        if (!Pattern.compile("^[a-z0-9!@#$%^&*(),.?\":{}|<>]+$").matcher(password).find()) {
-            throw new IllegalArgumentException("비밀번호는 소문자로 이루어져야 합니다.");
+        if (!Pattern.compile("[A-Z]").matcher(password).find()) {
+            throw new IllegalArgumentException("비밀번호에는 대문자가 최소 1자 이상 포함되어야 합니다.");
+        }
+        if (!Pattern.compile("[a-z]").matcher(password).find()) {
+            throw new IllegalArgumentException("비밀번호에는 소문자가 최소 1자 이상 포함되어야 합니다.");
         }
         if (!Pattern.compile("[0-9]").matcher(password).find()) {
-            throw new IllegalArgumentException("비밀번호는 숫자를 포함해야 합니다.");
+            throw new IllegalArgumentException("비밀번호에는 숫자가 최소 1자 이상 포함되어야 합니다.");
         }
         if (!Pattern.compile("[!@#$%^&*(),.?\":{}|<>]").matcher(password).find()) {
-            throw new IllegalArgumentException("비밀번호는 특수문자를 포함해야 합니다.");
+            throw new IllegalArgumentException("비밀번호에는 특수문자가 최소 1자 이상 포함되어야 합니다.");
         }
     }
 }

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -1,15 +1,16 @@
 package com.YOGIITSU.service;
 
 import com.YOGIITSU.dto.RequestDto.MemberSignUpRequestDto;
+import com.YOGIITSU.entity.EmailMessage;
 import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.repository.EmailMessageRepository;
 import com.YOGIITSU.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 @Service
@@ -17,78 +18,69 @@ import java.util.regex.Pattern;
 public class SignUpService {
 
     private final MemberRepository memberRepository;
+    private final EmailMessageRepository emailMessageRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public Map<String, String> register(MemberSignUpRequestDto memberSignUpRequestDto) {
-        Map<String, String> response = new HashMap<>();
+    public void register(MemberSignUpRequestDto dto) {
 
-        // 1. 아이디 중복 체크
-        if (memberRepository.findByMemberId(memberSignUpRequestDto.getMemberId()).isPresent()) {
-            response.put("message", "아이디가 이미 존재합니다.");
-            return response;
+        // 1. 이메일 인증 확인
+        Optional<EmailMessage> verifiedEmail = emailMessageRepository.findByEmailAndIsApprovedTrue(
+            dto.getEmail());
+        if (verifiedEmail.isEmpty()) {
+            throw new IllegalArgumentException("이메일 인증이 완료되지 않았습니다.");
         }
 
-        // 2. 이메일 중복 체크
-        if (memberRepository.findByEmail(memberSignUpRequestDto.getEmail()).isPresent()) {
-            response.put("message", "해당 이메일로 가입한 내역이 있습니다.");
-            return response;
+        // 2. 아이디 중복 체크
+        if (memberRepository.findByMemberId(dto.getMemberId()).isPresent()) {
+            throw new IllegalArgumentException("아이디가 이미 존재합니다.");
         }
 
-        // 이메일 도메인 검사
-        if (!memberSignUpRequestDto.getEmail().endsWith("@suwon.ac.kr")) {
-            response.put("message", "이메일은 무조건 @suwon.ac.kr로 끝나야 합니다.");
-            return response;
+        // 3. 이메일 중복 체크
+        if (memberRepository.findByEmail(dto.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("해당 이메일로 가입한 내역이 있습니다.");
         }
 
-        // 3. 이름 중복 체크
-        if (memberRepository.findByUserName(memberSignUpRequestDto.getUserName()).isPresent()) {
-            response.put("message", "해당 이름으로 가입한 내역이 있습니다.");
-            return response;
+        // 4. 이메일 도메인 검사
+        if (!dto.getEmail().endsWith("@suwon.ac.kr")) {
+            throw new IllegalArgumentException("이메일은 무조건 @suwon.ac.kr로 끝나야 합니다.");
         }
 
-        // 4. 이름 길이 검사 (최소 2글자 이상)
-        if (memberSignUpRequestDto.getUserName().length() < 2) {
-            response.put("message", "이름은 최소 2글자 이상이어야 합니다.");
-            return response;
+        // 5. 이름 중복 체크
+        if (memberRepository.findByUserName(dto.getUserName()).isPresent()) {
+            throw new IllegalArgumentException("해당 이름으로 가입한 내역이 있습니다.");
         }
 
-        // 5. 비밀번호 유효성 검사
-        try {
-            validatePassword(memberSignUpRequestDto.getPassword());
-        } catch (IllegalArgumentException e) {
-            response.put("message", e.getMessage());
-            return response;
+        // 6. 이름 길이 검사
+        if (dto.getUserName().length() < 2) {
+            throw new IllegalArgumentException("이름은 최소 2글자 이상이어야 합니다.");
         }
 
-        // 6. 비밀번호 암호화
-        String encodedPassword = passwordEncoder.encode(memberSignUpRequestDto.getPassword());
+        // 7. 비밀번호 유효성 검사
+        validatePassword(dto.getPassword());
 
-        // 7. Member 객체 생성
+        // 8. 비밀번호 암호화 및 회원 생성
+        String encodedPassword = passwordEncoder.encode(dto.getPassword());
+
         Member member = Member.builder()
-            .memberId(memberSignUpRequestDto.getMemberId())
+            .memberId(dto.getMemberId())
             .password(encodedPassword)
-            .email(memberSignUpRequestDto.getEmail())
-            .userName(memberSignUpRequestDto.getUserName())
-            .role("USER")
+            .email(dto.getEmail())
+            .userName(dto.getUserName())
+            .role("USER")  // 반드시 ROLE_ 접두사
             .joinAt(java.time.LocalDateTime.now())
             .build();
 
-        // 8. 데이터 저장
+        // 9. DB 저장
         memberRepository.save(member);
-
-        // 9. 성공 응답 반환
-        response.put("message", "회원가입이 성공적으로 완료되었습니다.");
-        return response;
     }
 
-    // 비밀번호 유효성 검사 메서드
     private void validatePassword(String password) {
         if (password.length() < 8) {
             throw new IllegalArgumentException("비밀번호는 최소 8글자여야 합니다.");
         }
-        if (!Pattern.compile("^[a-zA-Z0-9!@#$%^&*(),.?\":{}|<>]+$").matcher(password).find()) {
-            throw new IllegalArgumentException("비밀번호는 대소문자로 이루어져야 합니다.");
+        if (!Pattern.compile("^[a-z0-9!@#$%^&*(),.?\":{}|<>]+$").matcher(password).find()) {
+            throw new IllegalArgumentException("비밀번호는 소문자로 이루어져야 합니다.");
         }
         if (!Pattern.compile("[0-9]").matcher(password).find()) {
             throw new IllegalArgumentException("비밀번호는 숫자를 포함해야 합니다.");

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -79,11 +79,8 @@ public class SignUpService {
         if (password.length() < 8) {
             throw new IllegalArgumentException("비밀번호는 최소 8자 이상이어야 합니다.");
         }
-        if (!Pattern.compile("[A-Z]").matcher(password).find()) {
-            throw new IllegalArgumentException("비밀번호에는 대문자가 최소 1자 이상 포함되어야 합니다.");
-        }
-        if (!Pattern.compile("[a-z]").matcher(password).find()) {
-            throw new IllegalArgumentException("비밀번호에는 소문자가 최소 1자 이상 포함되어야 합니다.");
+        if (!Pattern.compile("[a-zA-Z]").matcher(password).find()) {
+            throw new IllegalArgumentException("비밀번호에는 영문자가 최소 1자 이상 포함되어야 합니다.");
         }
         if (!Pattern.compile("[0-9]").matcher(password).find()) {
             throw new IllegalArgumentException("비밀번호에는 숫자가 최소 1자 이상 포함되어야 합니다.");

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -6,6 +6,7 @@ import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.repository.EmailMessageRepository;
 import com.YOGIITSU.repository.MemberRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,8 @@ public class SignUpService {
     private final MemberRepository memberRepository;
     private final EmailMessageRepository emailMessageRepository;
     private final PasswordEncoder passwordEncoder;
+    private static final List<String> ALLOWED_DOMAINS = List.of("@suwon.ac.kr", "@gmail.com",
+        "@naver.com");
 
     @Transactional
     public void register(MemberSignUpRequestDto dto) {
@@ -42,8 +45,12 @@ public class SignUpService {
         }
 
         // 4. 이메일 도메인 검사
-        if (!dto.getEmail().endsWith("@suwon.ac.kr")) {
-            throw new IllegalArgumentException("이메일은 무조건 @suwon.ac.kr로 끝나야 합니다.");
+        boolean isValidDomain = ALLOWED_DOMAINS.stream()
+            .anyMatch(dto.getEmail()::endsWith);
+
+        if (!isValidDomain) {
+            throw new IllegalArgumentException(
+                "이메일은 suwon.ac.kr, gmail.com, naver.com 도메인만 허용됩니다.");
         }
 
         // 5. 이름 중복 체크

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -87,8 +87,8 @@ public class SignUpService {
         if (password.length() < 8) {
             throw new IllegalArgumentException("비밀번호는 최소 8글자여야 합니다.");
         }
-        if (!Pattern.compile("^[a-z0-9!@#$%^&*(),.?\":{}|<>]+$").matcher(password).find()) {
-            throw new IllegalArgumentException("비밀번호는 소문자로 이루어져야 합니다.");
+        if (!Pattern.compile("^[a-zA-Z0-9!@#$%^&*(),.?\":{}|<>]+$").matcher(password).find()) {
+            throw new IllegalArgumentException("비밀번호는 대소문자로 이루어져야 합니다.");
         }
         if (!Pattern.compile("[0-9]").matcher(password).find()) {
             throw new IllegalArgumentException("비밀번호는 숫자를 포함해야 합니다.");


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/signup` → `develop`

### 변경 사항

- 회원가입 시 이메일 인증 여부보다 이메일 중복 여부를 먼저 확인하도록 순서 변경
     - 기존에는 이미 가입된 이메일도 "이메일 인증이 완료되지 않았습니다."라는 메시지를 반환하던 문제 수정
- 아이디, 이름, 이메일 중복 체크 로직 정비
- 회원가입 요청 시 서비스 메서드 호출 후 일관된 성공 메시지 반환
- 이메일 인증 여부 확인용 메서드 findByEmailAndIsApprovedTrue(String email) 추가
- 8자 이상, 대문자 1자 이상, 소문자 1자 이상, 숫자 1자 이상, 특수문자 1자 이상 포함되도록 개별 조건 분리

### 테스트 결과

- 이미 가입된 이메일로 요청 시 → "해당 이메일로 가입한 내역이 있습니다."  메세지 정상 반환됨 

- 인증되지 않은 이메일로 회원가입 시 → "이메일 인증이 완료되지 않았습니다." 메시지 정상 반환됨

- DB에 정상 저장 확인
