### PR TITLE
fix: 로그인 실패 시 500 → 401 응답으로 수정

### DIFF
--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -42,6 +42,13 @@ public class GlobalExceptionHandler {
 		return buildErrorResponse(e.getMessage(), HttpStatus.FORBIDDEN);
 	}
 
+	// 로그인 실패 (잘못된 아이디/비밀번호)
+	@ExceptionHandler(InvalidLoginException.class)
+	public ResponseEntity<Map<String, String>> handleInvalidLoginException(
+		InvalidLoginException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.UNAUTHORIZED);
+	}
+
 	// 사용자를 찾을 수 없을 경우 예외 클래스 정의
 	@ExceptionHandler(MemberNotFoundException.class)
 	public ResponseEntity<Map<String, String>> handleMemberNotFoundException(
@@ -65,7 +72,8 @@ public class GlobalExceptionHandler {
 
 	// 이메일 인증이 승인되지 않은 경우 예외 처리
 	@ExceptionHandler(EmailVerificationNotApprovedException.class)
-	public ResponseEntity<Map<String, String>> handleNotApproved(EmailVerificationNotApprovedException e) {
+	public ResponseEntity<Map<String, String>> handleNotApproved(
+		EmailVerificationNotApprovedException e) {
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
 			.body(Map.of("message", e.getMessage()));
 	}
@@ -154,8 +162,16 @@ public class GlobalExceptionHandler {
 	}
 
 	public static class EmailVerificationNotApprovedException extends RuntimeException {
+
 		public EmailVerificationNotApprovedException() {
 			super("이메일 인증이 완료되지 않았습니다.");
+		}
+	}
+
+	public static class InvalidLoginException extends RuntimeException {
+
+		public InvalidLoginException() {
+			super("아이디 또는 비밀번호가 잘못되었습니다.");
 		}
 	}
 }

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.YOGIITSU.service;
 
-import com.YOGIITSU.config.handler.GlobalExceptionHandler.AdminAccessDeniedException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.EmailVerificationNotApprovedException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.InvalidLoginException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.MemberNotFoundException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.PasswordMismatchException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.PasswordNotEqualsException;
@@ -79,7 +79,7 @@ public class MemberService {
 
 		} catch (BadCredentialsException e) {
 			// 4. 인증 실패 시 예외 처리
-			throw new RuntimeException("아이디 또는 비밀번호가 잘못되었습니다", e);
+			throw new InvalidLoginException();
 		}
 	}
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 반영 브랜치

`feature/login` → `develop`


### 변경 사항

- 로그인 실패 시 발생하던 500 에러를 401 Unauthorized 응답으로 수정

- `InvalidLoginException` 커스텀 예외 클래스 추가
- `BadCredentialsException` 발생 시 `InvalidLoginException`으로 명시적으로 던지도록 변경
- `GlobalExceptionHandler`에 해당 예외 핸들러 추가하여 에러 메시지 통일


### 테스트 결과

- Swagger에서 잘못된 ID/PW 입력 시 500 → 401 응답 정상 확인

- 응답 메시지: `"message": "아이디 또는 비밀번호가 잘못되었습니다."`
- 로그인 성공/실패 로직 정상 동작 확인 완료