### PR TITLE
chore: CORS 설정을 환경변수로 변경하고 CI/CD에 시크릿 키 연동

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,15 +18,17 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
           PRIVATE_KEY: ${{ secrets.EC2_SSH_KEY }}
+          EC2_IP: ${{ secrets.EC2_IP }}
         run: |
           echo "Setting up SSH"
           mkdir -p ~/.ssh
           echo "$PRIVATE_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H 43.200.10.184 >> ~/.ssh/known_hosts
+          ssh-keyscan -H $EC2_IP >> ~/.ssh/known_hosts
 
           echo "Connecting to EC2 and deploying"
-          ssh ubuntu@43.200.10.184 << EOF
+          ssh ubuntu@$EC2_IP << EOF
+            export CORS_ALLOWED_ORIGIN=${{ secrets.CORS_ALLOWED_ORIGIN }}
             cd ~/YOGIITSU
             git pull origin develop
             ./deploy.sh

--- a/src/main/java/com/YOGIITSU/config/SecurityConfig.java
+++ b/src/main/java/com/YOGIITSU/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.YOGIITSU.jwt.JwtAuthenticationFilter;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,6 +25,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	@Value("${cors.allowed-origin}")
+	private String allowedOrigin;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -88,7 +91,7 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(Arrays.asList("http://43.200.10.184")); // 허용할 서버 IP
+		configuration.setAllowedOrigins(Arrays.asList(allowedOrigin)); // 허용할 서버 IP
 		configuration.setAllowedMethods(
 			Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH")); // 허용할 HTTP 메서드
 		configuration.setAllowedHeaders(


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [x]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`chore/dev-server` → `develop`

### 변경 사항
- `application.yml`에서 `allowed-origin`을 환경변수 `${CORS_ALLOWED_ORIGIN}`로 변경
- `SecurityConfig.java`에서 해당 환경변수 주입받도록 수정
- `cicd.yml`에서 EC2 IP와 CORS Origin을 GitHub Secrets로 대체
- SSH 접속 및 배포 단계에서 `CORS_ALLOWED_ORIGIN` 환경변수 export 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Deployment workflow now uses environment variables for EC2 IP and CORS allowed origin, improving flexibility and security.

- **New Features**
	- The app’s CORS allowed origin is now configurable via application properties, enabling easier updates without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->