### PR TITLE
feat: 건물 상세 조회 및 즐겨찾기 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.YOGIITSU.config.handler;
 
+import com.YOGIITSU.exception.building.BuildingNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -117,6 +118,13 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException e) {
 		return buildErrorResponse("서버 내부 오류 발생: " + e.getMessage(),
 			HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	// 건물 ID로 건물을 찾을 수 없는 경우 예외 처리
+	@ExceptionHandler(BuildingNotFoundException.class)
+	public ResponseEntity<Map<String, String>> handleBuildingNotFoundException(
+		BuildingNotFoundException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.NOT_FOUND);
 	}
 
 	public static class PasswordMismatchException extends RuntimeException {

--- a/src/main/java/com/YOGIITSU/controller/BuildingController.java
+++ b/src/main/java/com/YOGIITSU/controller/BuildingController.java
@@ -1,0 +1,48 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.dto.ResponseDto.BuildingDetailResponseDto;
+import com.YOGIITSU.service.BuildingService;
+import com.YOGIITSU.util.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "건물 관련 API", description = "건물 상세 정보 및 즐겨찾기 여부 조회 기능을 제공합니다.")
+@RestController
+@RequestMapping("/buildings")
+@RequiredArgsConstructor
+public class BuildingController {
+
+	private final BuildingService buildingService;
+	private final JwtUtil jwtUtil;
+
+	/**
+	 * 건물 상세 정보를 조회하는 API (즐겨찾기 여부 포함)
+	 *
+	 * @param id      조회할 건물의 ID
+	 * @param request HttpServletRequest (AccessToken 추출용)
+	 * @return 건물의 상세 정보를 담은 BuildingDetailResponseDto
+	 */
+	@Operation(
+		summary = "건물 상세 조회",
+		description = "건물 ID를 기반으로 상세 정보를 조회합니다.\n\n" +
+			"각 건물에 대한 사용자의 즐겨찾기 여부를 포함한 결과를 반환합니다."
+	)
+	@GetMapping("/{id}")
+	public BuildingDetailResponseDto getBuildingDetail(
+		@Parameter(description = "조회할 건물의 ID", example = "10")
+		@PathVariable Long id,
+
+		@Parameter(hidden = true)
+		HttpServletRequest request
+	) {
+		// 1. 로그인한 사용자인 경우 MemberId 추출
+		Long memberId = jwtUtil.extractMemberId(request);
+
+		// 2. 서비스 호출 → 즐겨찾기 여부까지 포함해서 반환
+		return buildingService.getBuildingDetail(id, memberId);
+	}
+}

--- a/src/main/java/com/YOGIITSU/converter/BuildingConverter.java
+++ b/src/main/java/com/YOGIITSU/converter/BuildingConverter.java
@@ -1,0 +1,90 @@
+package com.YOGIITSU.converter;
+
+import com.YOGIITSU.dto.ResponseDto.*;
+import com.YOGIITSU.entity.*;
+import java.util.ArrayList;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class BuildingConverter {
+
+	/**
+	 * Building 엔티티를 BuildingDetailResponseDto로 변환
+	 *
+	 * @param building 변환할 Building 엔티티
+	 * @return 변환된 BuildingDetailResponseDto
+	 */
+	public BuildingDetailResponseDto convertToBuildingDetailResponseDto(Building building,
+		boolean isFavorite) {
+		return BuildingDetailResponseDto.builder()
+			.buildingInfo(convertToBuildingInfoResponseDto(building))
+			.departments(convertToDepartmentResponseDtos(
+				new ArrayList<>(building.getDepartments())))
+			.floorPlans(convertToFloorPlanResponseDtos(
+				new ArrayList<>(building.getBuildingFloorImages())))
+			.isFavorite(isFavorite)
+			.build();
+	}
+
+	/**
+	 * Building 엔티티를 BuildingInfoResponseDto로 변환
+	 *
+	 * @param building 변환할 Building 엔티티
+	 * @return 변환된 BuildingInfoResponseDto
+	 */
+	private BuildingInfoResponseDto convertToBuildingInfoResponseDto(Building building) {
+		return BuildingInfoResponseDto.builder()
+			.name(building.getName())
+			.tags(building.getBuildingTags().stream()
+				.map(BuildingTag::getName)
+				.collect(Collectors.toList()))
+			.imageUrl(building.getImageUrl())
+			.facilities(building.getBuildingFacilities().stream()
+				.map(facility -> FacilityResponseDto.builder()
+					.name(facility.getName())
+					.floor(facility.getFloor())
+					.build())
+				.collect(Collectors.toList()))
+			.build();
+	}
+
+	/**
+	 * Building 엔티티의 Department 리스트를 DepartmentResponseDto 리스트로 변환
+	 *
+	 * @param departments 변환할 Department 리스트
+	 * @return 변환된 DepartmentResponseDto 리스트
+	 */
+	private List<DepartmentResponseDto> convertToDepartmentResponseDtos(
+		List<Department> departments) {
+		return departments.stream()
+			.map(department -> DepartmentResponseDto.builder()
+				.id(department.getId())
+				.collegeName(department.getCollegeName())
+				.departmentName(department.getDepartmentName())
+				.location(department.getLocation())
+				.phone(department.getPhone())
+				.fax(department.getFax())
+				.officeHours(department.getOfficeHours())
+				.build())
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * Building 엔티티의 BuildingFloorImage 리스트를 FloorPlanResponseDto 리스트로 변환
+	 *
+	 * @param floorImages 변환할 BuildingFloorImage 리스트
+	 * @return 변환된 FloorPlanResponseDto 리스트
+	 */
+	private List<FloorImageResponseDto> convertToFloorPlanResponseDtos(
+		List<BuildingFloorImage> floorImages) {
+		return floorImages.stream()
+			.map(floorImage -> FloorImageResponseDto.builder()
+				.floor(floorImage.getFloor())
+				.imageUrl(floorImage.getImageUrl())
+				.build())
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/BuildingDetailResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/BuildingDetailResponseDto.java
@@ -1,0 +1,18 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.Builder;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@Builder
+public class BuildingDetailResponseDto {
+
+	private BuildingInfoResponseDto buildingInfo;
+
+	private List<DepartmentResponseDto> departments;
+
+	private List<FloorImageResponseDto> floorPlans;
+
+	private boolean isFavorite;
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/BuildingInfoResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/BuildingInfoResponseDto.java
@@ -1,0 +1,20 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@Builder
+public class BuildingInfoResponseDto {
+
+	@NotBlank
+	private String name;
+
+	private List<String> tags;
+
+	private String imageUrl;
+
+	private List<FacilityResponseDto> facilities;
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/DepartmentResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/DepartmentResponseDto.java
@@ -1,0 +1,27 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DepartmentResponseDto {
+
+	private Long id;
+
+	@NotBlank
+	private String collegeName;
+
+	@NotBlank
+	private String departmentName;
+
+	@NotBlank
+	private String location;
+
+	private String phone;
+
+	private String fax;
+
+	private String officeHours;
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/FacilityResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/FacilityResponseDto.java
@@ -1,0 +1,15 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FacilityResponseDto {
+
+	@NotBlank
+	private String name;
+
+	private String floor;
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/FloorImageResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/FloorImageResponseDto.java
@@ -1,0 +1,13 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FloorImageResponseDto {
+
+	private String floor;
+
+	private String imageUrl;
+}

--- a/src/main/java/com/YOGIITSU/entity/Building.java
+++ b/src/main/java/com/YOGIITSU/entity/Building.java
@@ -1,6 +1,9 @@
 package com.YOGIITSU.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,4 +33,7 @@ public class Building {
 	@Column(name = "image_url")
 	private String imageUrl;
 
+	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
+	@JsonManagedReference
+	private Set<BuildingFacility> buildingFacilities = new HashSet<>();
 }

--- a/src/main/java/com/YOGIITSU/entity/Building.java
+++ b/src/main/java/com/YOGIITSU/entity/Building.java
@@ -44,4 +44,8 @@ public class Building {
 	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
 	private Set<BuildingTag> buildingTags = new HashSet<>();
+
+	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
+	@JsonManagedReference
+	private Set<Department> departments = new HashSet<>();
 }

--- a/src/main/java/com/YOGIITSU/entity/Building.java
+++ b/src/main/java/com/YOGIITSU/entity/Building.java
@@ -40,4 +40,8 @@ public class Building {
 	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
 	private Set<BuildingFloorImage> buildingFloorImages = new HashSet<>();
+
+	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
+	@JsonManagedReference
+	private Set<BuildingTag> buildingTags = new HashSet<>();
 }

--- a/src/main/java/com/YOGIITSU/entity/Building.java
+++ b/src/main/java/com/YOGIITSU/entity/Building.java
@@ -36,4 +36,8 @@ public class Building {
 	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
 	private Set<BuildingFacility> buildingFacilities = new HashSet<>();
+
+	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
+	@JsonManagedReference
+	private Set<BuildingFloorImage> buildingFloorImages = new HashSet<>();
 }

--- a/src/main/java/com/YOGIITSU/entity/BuildingFacility.java
+++ b/src/main/java/com/YOGIITSU/entity/BuildingFacility.java
@@ -1,0 +1,29 @@
+package com.YOGIITSU.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "building_facilities")
+public class BuildingFacility {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "building_id", nullable = false)
+	@JsonBackReference
+	private Building building;
+
+	@Column(nullable = false)
+	private String name;
+
+	private String floor;
+}

--- a/src/main/java/com/YOGIITSU/entity/BuildingFloorImage.java
+++ b/src/main/java/com/YOGIITSU/entity/BuildingFloorImage.java
@@ -1,0 +1,28 @@
+package com.YOGIITSU.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "building_floor_image")
+public class BuildingFloorImage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "building_id", nullable = false)
+	@JsonBackReference
+	private Building building;
+
+	private String floor;
+
+	private String imageUrl;
+}

--- a/src/main/java/com/YOGIITSU/entity/BuildingTag.java
+++ b/src/main/java/com/YOGIITSU/entity/BuildingTag.java
@@ -1,0 +1,27 @@
+package com.YOGIITSU.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "building_tag")
+public class BuildingTag {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "building_id", nullable = false)
+	@JsonBackReference
+	private Building building;
+
+	@Column(nullable = false)
+	private String name;
+}

--- a/src/main/java/com/YOGIITSU/entity/Department.java
+++ b/src/main/java/com/YOGIITSU/entity/Department.java
@@ -1,0 +1,37 @@
+package com.YOGIITSU.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "departments")
+public class Department {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "building_id", nullable = false)
+	@JsonBackReference
+	private Building building;
+
+	@Column(nullable = false)
+	private String collegeName;
+
+	@Column(nullable = false)
+	private String departmentName;
+
+	@Column(nullable = false)
+	private String location;
+
+	private String phone;
+
+	private String fax;
+
+	private String officeHours;
+}

--- a/src/main/java/com/YOGIITSU/exception/building/BuildingNotFoundException.java
+++ b/src/main/java/com/YOGIITSU/exception/building/BuildingNotFoundException.java
@@ -1,0 +1,8 @@
+package com.YOGIITSU.exception.building;
+
+public class BuildingNotFoundException extends RuntimeException {
+
+	public BuildingNotFoundException(Long buildingId) {
+		super("존재하지 않는 건물입니다. buildingId=" + buildingId);
+	}
+}

--- a/src/main/java/com/YOGIITSU/repository/BuildingRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/BuildingRepository.java
@@ -2,11 +2,22 @@ package com.YOGIITSU.repository;
 
 import com.YOGIITSU.entity.Building;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BuildingRepository extends JpaRepository<Building, Long> {
 
 	// 입력된 검색어(query)가 포함된 건물 이름을 최대 6개까지 반환
 	List<Building> findTop6ByNameContainingOrderByNameAsc(String query);
 
+	// 건물 ID로 건물 조회
+	@Query("SELECT b FROM Building b " +
+		"LEFT JOIN FETCH b.buildingTags " +
+		"LEFT JOIN FETCH b.buildingFacilities " +
+		"LEFT JOIN FETCH b.buildingFloorImages " +
+		"LEFT JOIN FETCH b.departments " +
+		"WHERE b.id = :id")
+	Optional<Building> findByIdWithAllRelations(@Param("id") Long id);
 }

--- a/src/main/java/com/YOGIITSU/repository/FavoriteRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/FavoriteRepository.java
@@ -17,4 +17,7 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
 	// 사용자 ID와 건물 ID로 즐겨찾기 삭제
 	void deleteByMemberAndBuilding(Member member, Building building);
+
+	// 사용자 ID와 건물 ID로 즐겨찾기 존재 여부 확인
+	boolean existsByMemberIdAndBuildingId(Long memberId, Long buildingId);
 }

--- a/src/main/java/com/YOGIITSU/service/BuildingService.java
+++ b/src/main/java/com/YOGIITSU/service/BuildingService.java
@@ -1,0 +1,49 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.converter.BuildingConverter;
+import com.YOGIITSU.dto.ResponseDto.BuildingDetailResponseDto;
+import com.YOGIITSU.entity.Building;
+import com.YOGIITSU.exception.building.BuildingNotFoundException;
+import com.YOGIITSU.repository.BuildingRepository;
+import com.YOGIITSU.repository.FavoriteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BuildingService {
+
+	private final BuildingRepository buildingRepository;
+	private final FavoriteRepository favoriteRepository;
+	private final BuildingConverter buildingConverter;
+
+	/**
+	 * 건물 상세 정보를 조회하는 메서드
+	 *
+	 * @param buildingId 조회할 건물의 ID
+	 * @param memberId   조회하는 사용자의 ID (즐겨찾기 여부 확인용)
+	 * @return 건물의 상세 정보를 담은 BuildingDetailResponseDto
+	 */
+	@Transactional(readOnly = true)
+	public BuildingDetailResponseDto getBuildingDetail(Long buildingId, Long memberId) {
+		Building building = findBuildingById(buildingId);
+
+		//즐겨찾기 여부 조회
+		boolean isFavorite = favoriteRepository.existsByMemberIdAndBuildingId(memberId, buildingId);
+
+		return buildingConverter.convertToBuildingDetailResponseDto(building, isFavorite);
+	}
+
+	/**
+	 * 건물 ID로 건물을 조회하는 메서드
+	 *
+	 * @param buildingId 조회할 건물의 ID
+	 * @return 조회된 Building 엔티티
+	 * @throws BuildingNotFoundException 건물이 존재하지 않을 경우 발생하는 예외
+	 */
+	private Building findBuildingById(Long buildingId) {
+		return buildingRepository.findByIdWithAllRelations(buildingId)
+			.orElseThrow(() -> new BuildingNotFoundException(buildingId));
+	}
+}

--- a/src/test/java/com/YOGIITSU/service/BuildingServiceTest.java
+++ b/src/test/java/com/YOGIITSU/service/BuildingServiceTest.java
@@ -1,0 +1,74 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.converter.BuildingConverter;
+import com.YOGIITSU.dto.ResponseDto.BuildingDetailResponseDto;
+import com.YOGIITSU.entity.Building;
+import com.YOGIITSU.exception.building.BuildingNotFoundException;
+import com.YOGIITSU.repository.BuildingRepository;
+import com.YOGIITSU.repository.FavoriteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class BuildingServiceTest {
+
+	@Mock
+	private BuildingRepository buildingRepository;
+
+	@Mock
+	private FavoriteRepository favoriteRepository;
+
+	@Mock
+	private BuildingConverter buildingConverter;
+
+	@InjectMocks
+	private BuildingService buildingService;
+
+	@DisplayName("건물상세조회_성공")
+	@Test
+	void getBuildingDetail_success() {
+		// given
+		Long buildingId = 1L;
+		Long memberId = 1L;
+		Building building = createDummyBuilding();
+		when(buildingRepository.findByIdWithAllRelations(buildingId)).thenReturn(
+			Optional.of(building));
+		when(favoriteRepository.existsByMemberIdAndBuildingId(memberId, buildingId)).thenReturn(
+			true);
+		when(buildingConverter.convertToBuildingDetailResponseDto(building, true))
+			.thenReturn(BuildingDetailResponseDto.builder().build());
+
+		// when
+		BuildingDetailResponseDto result = buildingService.getBuildingDetail(buildingId, memberId);
+
+		// then
+		assertNotNull(result);
+	}
+
+	@DisplayName("건물상세조회_실패_건물없음")
+	@Test
+	void getBuildingDetail_fail_buildingNotFound() {
+		// given
+		Long buildingId = 999L;
+		Long memberId = 1L;
+		when(buildingRepository.findByIdWithAllRelations(buildingId)).thenReturn(Optional.empty());
+
+		// when, then
+		assertThrows(BuildingNotFoundException.class,
+			() -> buildingService.getBuildingDetail(buildingId, memberId));
+	}
+
+	private Building createDummyBuilding() {
+		return Building.builder()
+			.name("테스트건물")
+			.build();
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`feature/building` → `develop`

### 변경 사항

- BuildingFacility, BuildingFloorImage, BuildingTag, Department 엔티티 생성 및 Building과 연관관계 설정

- Building 상세 조회를 위한 `findByIdWithAllRelations` 쿼리 추가
- BuildingDetailResponseDto 및 하위 응답 DTO들 생성 (BuildingInfo, Department, Facility, FloorImage)
- Building 상세 조회용 Converter 로직 구현
- BuildingService에 건물 상세 조회 및 즐겨찾기 여부 반환 기능 추가
- FavoriteRepository에 사용자-건물 기준 즐겨찾기 여부 확인 메서드 추가
- BuildingNotFoundException 예외 및 예외 처리 추가
- BuildingController에 건물 상세 조회 API 및 Swagger 문서 작성

### 테스트 결과

- Swagger를 통해 Building 상세 조회 API 정상 동작 확인

- JWT 기반 인증 사용자 요청 시 즐겨찾기 여부도 정확히 반환되는지 검증 완료
- DB에 존재하지 않는 건물 ID 조회 시 `BuildingNotFoundException` 정상 발생 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 건물 상세 정보를 조회할 수 있는 API가 추가되었습니다. 건물의 기본 정보, 관련 학과, 층별 이미지, 즐겨찾기 여부 등을 한 번에 확인할 수 있습니다.
- **버그 수정**
    - 존재하지 않는 건물 조회 시 404 오류와 함께 안내 메시지가 반환됩니다.
- **테스트**
    - 건물 상세 조회 서비스에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->