### PR TITLE
feat: 건물 검색/상세 응답 확장 및 Swagger 문서 개선

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/BuildingController.java
+++ b/src/main/java/com/YOGIITSU/controller/BuildingController.java
@@ -28,12 +28,36 @@ public class BuildingController {
 	 */
 	@Operation(
 		summary = "건물 상세 조회",
-		description = "건물 ID를 기반으로 상세 정보를 조회합니다.\n\n" +
-			"각 건물에 대한 사용자의 즐겨찾기 여부를 포함한 결과를 반환합니다."
+		description = """
+			건물 ID를 기반으로 상세 정보를 조회합니다. <br>
+			각 건물에 대한 사용자의 즐겨찾기 여부를 포함한 결과를 반환합니다. <br><br>
+
+			사용 가능한 건물 ID 목록:<br>
+			1: 인문사회융합대학<br>
+			2: 체육관<br>
+			3: 미래혁신관<br>
+			4: 혁신공과대학<br>
+			5: 공학관<br>
+			6: ACE 교육관<br>
+			7: 디자인앤아트대학<br>
+			8: 조형관<br>
+			9: 음악테크놀로지대학<br>
+			10: 지능형SW융합대학<br>
+			11: 라이프케어사이언스대학<br>
+			12: 사회관<br>
+			13: 문화예술융합대학<br>
+			14: 경영공학대학
+			"""
 	)
+
 	@GetMapping("/{id}")
 	public BuildingDetailResponseDto getBuildingDetail(
-		@Parameter(description = "조회할 건물의 ID", example = "10")
+		@Parameter(
+			description = "조회할 건물의 ID<br><br>" +
+				"예시:<br>10 → 지능형SW융합대학<br>14 → 경영공학대학",
+			example = "10"
+		)
+
 		@PathVariable Long id,
 
 		@Parameter(hidden = true)

--- a/src/main/java/com/YOGIITSU/converter/BuildingConverter.java
+++ b/src/main/java/com/YOGIITSU/converter/BuildingConverter.java
@@ -42,6 +42,8 @@ public class BuildingConverter {
 				.map(BuildingTag::getName)
 				.collect(Collectors.toList()))
 			.imageUrl(building.getImageUrl())
+			.latitude(building.getLatitude())
+			.longitude(building.getLongitude())
 			.facilities(building.getBuildingFacilities().stream()
 				.map(facility -> FacilityResponseDto.builder()
 					.name(facility.getName())

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/BuildingInfoResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/BuildingInfoResponseDto.java
@@ -17,4 +17,8 @@ public class BuildingInfoResponseDto {
 	private String imageUrl;
 
 	private List<FacilityResponseDto> facilities;
+
+	private Double latitude;
+
+	private Double longitude;
 }

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/SearchSuggestionResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/SearchSuggestionResponseDto.java
@@ -1,11 +1,14 @@
 package com.YOGIITSU.dto.ResponseDto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class SearchSuggestionResponseDto {
-	private String keyword;
-	private boolean isBookmarked;
+	private Long buildingId;     // 건물 ID
+	private String keyword;      // 건물 이름 or 별칭
+	private boolean isBookmarked; // 즐겨찾기 여부
+	private List<String> tags;   // 태그 목록
 }

--- a/src/main/java/com/YOGIITSU/service/SearchSuggestionService.java
+++ b/src/main/java/com/YOGIITSU/service/SearchSuggestionService.java
@@ -3,6 +3,7 @@ package com.YOGIITSU.service;
 import com.YOGIITSU.dto.ResponseDto.SearchSuggestionResponseDto;
 import com.YOGIITSU.entity.Building;
 import com.YOGIITSU.entity.BuildingAlias;
+import com.YOGIITSU.entity.BuildingTag;
 import com.YOGIITSU.entity.Favorite;
 import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.repository.BuildingAliasRepository;
@@ -14,9 +15,11 @@ import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SearchSuggestionService {
 
 	private final BuildingRepository buildingRepository;
@@ -81,19 +84,33 @@ public class SearchSuggestionService {
 
 		// 즐겨찾기된 건물 먼저 추가
 		for (Building building : bookmarkedBuildings) {
-			finalResults.add(new SearchSuggestionResponseDto(building.getName(), true));
+			finalResults.add(new SearchSuggestionResponseDto(
+				building.getId(),
+				building.getName(),
+				true,
+				building.getBuildingTags().stream()
+					.map(BuildingTag::getName)
+					.collect(Collectors.toList())
+			));
 		}
 
 		// 일반 검색 결과에서 중복되지 않는 건물 추가
 		for (Building building : searchResults) {
 			if (!bookmarkedBuildingIds.contains(building.getId())) {
-				finalResults.add(new SearchSuggestionResponseDto(building.getName(), false));
+				finalResults.add(new SearchSuggestionResponseDto(
+					building.getId(),
+					building.getName(),
+					false,
+					building.getBuildingTags().stream()
+						.map(BuildingTag::getName)
+						.collect(Collectors.toList())
+				));
 			}
 		}
 
-		// 최대 6개만 반환
 		return finalResults.stream()
 			.limit(6)
 			.collect(Collectors.toList());
 	}
+
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/building` → `develop`

### 변경 사항

- **검색 자동완성 API 응답 확장**
    - `/search/suggestions` 응답에 `buildingId`, `tags` 필드 추가
    - 프론트에서 검색결과 클릭 시 별도의 건물 상세 조회 없이도 식별 가능하도록 개선
    
- **건물 상세 응답 확장**
    - `BuildingDetailResponseDto`에 `latitude`, `longitude` 필드 추가
    - 기존 `Building` Entity에 위도/경도 필드가 포함되어 있었고, 응답 DTO로 매핑

- Swagger 문서 (`@Operation`, `@Parameter`) 설명에 다음 항목 추가:
    - 건물 ID별 실제 대응 명칭 리스트


### 테스트 결과

- `/search/suggestions` 응답에 `buildingId`, `tags` 포함되는지 확인
-  `/buildings/{id}` 응답에 `latitude`, `longitude` 포함 확인
-  Swagger 문서에서 건물 ID 예시 정상 적용됨
- 기존 기능 영향 없이 정상 작동


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 건물 정보 응답에 위도(latitude)와 경도(longitude) 정보가 추가되었습니다.
    - 검색 제안 응답에 건물 ID, 태그 목록, 기존 북마크 여부와 키워드 외 추가 정보가 포함됩니다.

- **문서화**
    - 건물 상세 조회 API의 설명이 더 구체적으로 개선되어, 유효한 건물 ID와 이름 목록, 예시 등이 명확하게 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->