### PR TITLE
refactor: 문의 API 응답 구조 리팩토링 및 상세 조회 방식 통합

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/InquiryController.java
+++ b/src/main/java/com/YOGIITSU/controller/InquiryController.java
@@ -42,6 +42,7 @@ public class InquiryController {
     /**
      * 문의 등록 API
      * - 인증된 사용자가 문의 등록
+     * - 응답 body 없이 204 반환
      */
     @Operation(summary = "문의 등록")
     @PostMapping
@@ -49,51 +50,33 @@ public class InquiryController {
         @RequestBody InquiryRequestDto requestDto,
         @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        // JWT 토큰에서 memberId 추출
         inquiryService.createInquiry(requestDto, userDetails.getId());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     /**
      * 전체 문의 리스트 조회 API
-     * - 로그인 한 모든 사용자가 확인 가능
+     * - 전체 공개 (모든 로그인 사용자 접근 가능)
      */
     @Operation(summary = "전체 문의 목록 조회")
     @GetMapping
     public ResponseEntity<List<InquiryListResponseDto>> getAllInquiries(
         HttpServletRequest request) {
-        // 1. 요청에서 JWT 토큰 추출
-        String token = jwtTokenProvider.resolveToken(request);
 
-        // 2. 토큰 없으면 401 에러
-        if (token == null) {
-            throw new MissingTokenException(); // custom 예외: "토큰 없음"
-        }
-
-        // 3. 토큰이 유효하지 않으면 401 에러
-        if (!jwtTokenProvider.validateToken(token)) {
-            throw new InvalidTokenException(); // custom 예외: "유효하지 않은 토큰"
-        }
-
-        // 토큰 유효하면 전체 문의 리스트 반환
+        validateToken(request);  // 인증 여부만 확인
         return ResponseEntity.ok(inquiryService.getAllInquiries());
     }
 
     /**
-     * 나의 문의 조회 API
-     * - 인증된 사용자만 본인의 문의를 확인 가능
+     * 문의 상세 조회 (전체 공개)
+     * - 본인 여부와 관계 없이 열람 가능
      */
-    @Operation(summary = "나의 문의 조회")
+    @Operation(summary = "문의 상세 조회")
     @GetMapping("/{inquiryId}")
     public ResponseEntity<InquiryResponseDto> getInquiry(
-        @PathVariable Long inquiryId,
-        HttpServletRequest request) {
+        @PathVariable Long inquiryId) {
 
-        // JWT 토큰에서 memberId 추출
-        Long memberId = extractMemberIdFromToken(request);
-
-        // 문의 단건 조회
-        InquiryResponseDto response = inquiryService.getInquiry(inquiryId, memberId);
+        InquiryResponseDto response = inquiryService.getInquiry(inquiryId);
         return ResponseEntity.ok(response);
     }
 
@@ -108,7 +91,6 @@ public class InquiryController {
         @RequestBody @Valid InquiryRequestDto requestDto,
         HttpServletRequest request) {
 
-        // JWT 토큰에서 memberId 추출
         Long memberId = extractMemberIdFromToken(request);
 
         // 문의 수정
@@ -138,6 +120,7 @@ public class InquiryController {
      * JWT 토큰에서 memberId 추출
      */
     private Long extractMemberIdFromToken(HttpServletRequest request) {
+
         String token = jwtTokenProvider.resolveToken(request);
 
         if (token == null) {
@@ -148,11 +131,22 @@ public class InquiryController {
         }
 
         String memberId = jwtTokenProvider.getAuthentication(token).getName();
-
         Member member = memberRepository.findByMemberId(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
         return member.getId();
+    }
+
+    private void validateToken(HttpServletRequest request) {
+
+        String token = jwtTokenProvider.resolveToken(request);
+
+        if (token == null) {
+            throw new MissingTokenException();
+        }
+        if (!jwtTokenProvider.validateToken(token)) {
+            throw new InvalidTokenException();
+        }
     }
 
 }

--- a/src/main/java/com/YOGIITSU/controller/InquiryController.java
+++ b/src/main/java/com/YOGIITSU/controller/InquiryController.java
@@ -46,12 +46,12 @@ public class InquiryController {
      */
     @Operation(summary = "문의 등록")
     @PostMapping
-    public ResponseEntity<Void> createInquiry(
+    public ResponseEntity<String> createInquiry(
         @RequestBody InquiryRequestDto requestDto,
         @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         inquiryService.createInquiry(requestDto, userDetails.getId());
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.status(HttpStatus.CREATED).body("등록이 완료되었습니다.");
     }
 
     /**

--- a/src/main/java/com/YOGIITSU/controller/InquiryController.java
+++ b/src/main/java/com/YOGIITSU/controller/InquiryController.java
@@ -121,14 +121,8 @@ public class InquiryController {
      */
     private Long extractMemberIdFromToken(HttpServletRequest request) {
 
+        validateToken(request);
         String token = jwtTokenProvider.resolveToken(request);
-
-        if (token == null) {
-            throw new MissingTokenException();
-        }
-        if (!jwtTokenProvider.validateToken(token)) {
-            throw new InvalidTokenException();
-        }
 
         String memberId = jwtTokenProvider.getAuthentication(token).getName();
         Member member = memberRepository.findByMemberId(memberId)
@@ -137,6 +131,9 @@ public class InquiryController {
         return member.getId();
     }
 
+    /**
+     * JWT 토큰 유효성 검사
+     */
     private void validateToken(HttpServletRequest request) {
 
         String token = jwtTokenProvider.resolveToken(request);

--- a/src/main/java/com/YOGIITSU/controller/InquiryController.java
+++ b/src/main/java/com/YOGIITSU/controller/InquiryController.java
@@ -1,6 +1,7 @@
 package com.YOGIITSU.controller;
 
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.InvalidTokenException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.MemberNotFoundException;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.MissingTokenException;
 import com.YOGIITSU.dto.RequestDto.InquiryRequestDto;
 import com.YOGIITSU.dto.ResponseDto.InquiryListResponseDto;
@@ -126,7 +127,7 @@ public class InquiryController {
 
         String memberId = jwtTokenProvider.getAuthentication(token).getName();
         Member member = memberRepository.findByMemberId(memberId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+            .orElseThrow(MemberNotFoundException::new);
 
         return member.getId();
     }

--- a/src/main/java/com/YOGIITSU/controller/InquiryController.java
+++ b/src/main/java/com/YOGIITSU/controller/InquiryController.java
@@ -6,6 +6,7 @@ import com.YOGIITSU.dto.RequestDto.InquiryRequestDto;
 import com.YOGIITSU.dto.ResponseDto.InquiryListResponseDto;
 import com.YOGIITSU.dto.ResponseDto.InquiryResponseDto;
 import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.jwt.CustomUserDetails;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import com.YOGIITSU.repository.MemberRepository;
 import com.YOGIITSU.service.InquiryService;
@@ -15,7 +16,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -42,16 +45,13 @@ public class InquiryController {
      */
     @Operation(summary = "문의 등록")
     @PostMapping
-    public ResponseEntity<InquiryResponseDto> createInquiry(
-        @RequestBody @Valid InquiryRequestDto requestDto,
-        HttpServletRequest request) {
+    public ResponseEntity<Void> createInquiry(
+        @RequestBody InquiryRequestDto requestDto,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         // JWT 토큰에서 memberId 추출
-        Long memberId = extractMemberIdFromToken(request);
-
-        // 문의 등록
-        InquiryResponseDto response = inquiryService.createInquiry(requestDto, memberId);
-        return ResponseEntity.ok(response);
+        inquiryService.createInquiry(requestDto, userDetails.getId());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     /**

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryListResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryListResponseDto.java
@@ -22,7 +22,7 @@ public class InquiryListResponseDto {
         this.inquiryId = inquiry.getInquiryId();
         this.inquiryTitle = inquiry.getInquiryTitle();
         this.authorId = inquiry.getMember().getId();
-        this.authorName = inquiry.getMember().getUsername();
+        this.authorName = inquiry.getMember().getUserName();
         this.inquiryState = inquiry.getInquiryState().name();  // "PROCESSING", "COMPLETED"
         this.inquiryAt = inquiry.getInquiryAt();
     }

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryListResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryListResponseDto.java
@@ -11,13 +11,17 @@ import lombok.Getter;
 @Getter
 public class InquiryListResponseDto {
 
+    private final Long inquiryId;
     private final String inquiryTitle;
+    private final Long authorId;
     private final String authorName;
     private final String inquiryState;
     private final LocalDateTime inquiryAt;
 
     public InquiryListResponseDto(Inquiry inquiry) {
+        this.inquiryId = inquiry.getInquiryId();
         this.inquiryTitle = inquiry.getInquiryTitle();
+        this.authorId = inquiry.getMember().getId();
         this.authorName = inquiry.getMember().getUsername();
         this.inquiryState = inquiry.getInquiryState().name();  // "PROCESSING", "COMPLETED"
         this.inquiryAt = inquiry.getInquiryAt();

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryResponseDto.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class InquiryResponseDto {
 
-    private Long inquiryId;
     private String inquiryTitle;
     private String inquiryContent;
     private LocalDateTime inquiryAt;
@@ -26,12 +25,12 @@ public class InquiryResponseDto {
     private LocalDateTime responseAt;
 
     public InquiryResponseDto(Inquiry inquiry) {
-        this.inquiryId = inquiry.getInquiryId();
+
         this.inquiryTitle = inquiry.getInquiryTitle();
         this.inquiryContent = inquiry.getInquiryContent();
+        this.inquiryAt = inquiry.getInquiryAt();
         this.authorId = inquiry.getMember().getId();
         this.authorName = inquiry.getMember().getUserName();
-        this.inquiryAt = inquiry.getInquiryAt();
         this.response = inquiry.getResponse();
         this.responseAt = inquiry.getResponseAt();
     }

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryResponseDto.java
@@ -17,16 +17,22 @@ public class InquiryResponseDto {
     private Long inquiryId;
     private String inquiryTitle;
     private String inquiryContent;
-    private String response;
     private LocalDateTime inquiryAt;
+
+    private Long authorId;
+    private String authorName;
+
+    private String response;
     private LocalDateTime responseAt;
 
     public InquiryResponseDto(Inquiry inquiry) {
         this.inquiryId = inquiry.getInquiryId();
         this.inquiryTitle = inquiry.getInquiryTitle();
         this.inquiryContent = inquiry.getInquiryContent();
-        this.response = inquiry.getResponse();
+        this.authorId = inquiry.getMember().getId();
+        this.authorName = inquiry.getMember().getUserName();
         this.inquiryAt = inquiry.getInquiryAt();
+        this.response = inquiry.getResponse();
         this.responseAt = inquiry.getResponseAt();
     }
 }

--- a/src/main/java/com/YOGIITSU/service/InquiryService.java
+++ b/src/main/java/com/YOGIITSU/service/InquiryService.java
@@ -78,18 +78,17 @@ public class InquiryService {
     }
 
     /**
-     * Read-my: 개인 문의 조회
-     * - 본인 문의만 조회 가능
-     * - 전체 내용 포함한 DTO 반환
+     * Read: 문의 상세 조회
+     * - 전체 공개
+     * - 나의 문의 일 때만 수정, 삭제 가능
      *
-     * @param inquiryId 문의 ID
-     * @param memberId  사용자 ID
-     * @return InquiryResponseDto 개인 문의 정보
+     * @param inquiryId
+     * @param memberId
+     * @return
      */
     @Transactional(readOnly = true)
-    public InquiryResponseDto getInquiry(Long inquiryId, Long memberId) {
+    public InquiryResponseDto getInquiry(Long inquiryId) {
         Inquiry inquiry = findInquiry(inquiryId);
-        validateOwnership(inquiry, memberId);
 
         // 문의 정보 반환
         return new InquiryResponseDto(inquiry);
@@ -111,7 +110,7 @@ public class InquiryService {
         // 1. 해당 문의 조회
         Inquiry inquiry = findInquiry(inquiryId);
 
-        // 2. 본인이 작성한 문의인지 확인 (비밀번호 검증은 단건 조회에서 완료)
+        // 2. 본인이 작성한 문의인지 확인
         validateOwnership(inquiry, memberId);
 
         // 3. 관리자 답변이 있는 경우 수정 불가
@@ -162,7 +161,7 @@ public class InquiryService {
     }
 
     /**
-     * 특정 ID의 문의 조회 (예외 처리 포함)
+     * 문의 조회 (예외 처리 포함)
      *
      * @param inquiryId 문의 ID
      * @return Inquiry 조회된 문의 객체
@@ -177,7 +176,7 @@ public class InquiryService {
      */
     private void validateOwnership(Inquiry inquiry, Long memberId) {
         if (!inquiry.getMember().getId().equals(memberId)) {
-            throw new IllegalArgumentException("본인이 작성한 문의만 조회할 수 있습니다.");
+            throw new IllegalArgumentException("본인이 작성한 문의만 수정 또는 삭제할 수 있습니다.");
         }
     }
 

--- a/src/main/java/com/YOGIITSU/service/InquiryService.java
+++ b/src/main/java/com/YOGIITSU/service/InquiryService.java
@@ -36,7 +36,6 @@ public class InquiryService {
      *
      * @param requestDto 문의 요청 데이터
      * @param memberId   문의 작성한 회원 ID
-     * @return InquiryResponseDto 등록된 문의 정보
      */
     @Transactional
     public void createInquiry(InquiryRequestDto requestDto, Long memberId) {
@@ -82,9 +81,8 @@ public class InquiryService {
      * - 전체 공개
      * - 나의 문의 일 때만 수정, 삭제 가능
      *
-     * @param inquiryId
-     * @param memberId
-     * @return
+     * @param inquiryId 문의 ID
+     * @return InquiryResponseDto 문의 상세 정보
      */
     @Transactional(readOnly = true)
     public InquiryResponseDto getInquiry(Long inquiryId) {

--- a/src/main/java/com/YOGIITSU/service/InquiryService.java
+++ b/src/main/java/com/YOGIITSU/service/InquiryService.java
@@ -39,7 +39,7 @@ public class InquiryService {
      * @return InquiryResponseDto 등록된 문의 정보
      */
     @Transactional
-    public InquiryResponseDto createInquiry(InquiryRequestDto requestDto, Long memberId) {
+    public void createInquiry(InquiryRequestDto requestDto, Long memberId) {
 
         // 1. 회원 조회
         Member member = findMember(memberId);
@@ -59,9 +59,8 @@ public class InquiryService {
             .inquiryState(InquiryState.PROCESSING)  // 기본 상태: PROCESSING(답변대기)
             .build();
 
-        // 2. 생성된 문의 DB에 저장 & 반환
-        Inquiry savedInquiry = inquiryRepository.save(inquiry);
-        return new InquiryResponseDto(savedInquiry);
+        // 3. 생성된 문의 DB에 저장
+        inquiryRepository.save(inquiry);
     }
 
     /**


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`refactor/inquiry-response` → `develop`

### 변경 사항
- InquiryResponseDto에서 불필요한 필드 (`inquiryId` 등) 제거 및 `authorId`, `authorName` 추가
- 상세 조회 시 `getInquiry` 내부에서 작성자 여부(`authorId`) 판단
- 전체 문의 목록, 단건 상세 조회는 로그인 사용자 누구나 접근 가능하도록 변경
- InquiryController의 수정/삭제 요청만 인증 여부 검증 -> 비작성자는 400 예외 반환
- 문의 등록 응답값을 프론트 요청에 따라 `204 No Content`로 변경
- Swagger 문서 요약 정비 및 관련 주석 수정

### 테스트 결과
- Swagger를 통해 모든 API 정상 동작 확인
    - 문의 등록: 204 반환
    - 전체 목록 조회: 로그인 사용자 모두 가능
    - 단건 상세 조회: 본인/타인 구분 없이 모두 열람 가능
    - 수정/삭제: 본인 + 답변 대기 상태만 가능, 그 외 400 예외 반환 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 문의 목록과 상세 조회 시 작성자 ID와 이름 정보가 추가로 표시됩니다.

- **버그 수정**
  - 문의 생성 시 응답 메시지와 함께 201 Created 상태로 처리됩니다.

- **리팩터**
  - 토큰 검증 로직이 중앙화되어 인증 절차가 간소화되었습니다.
  - 문의 조회는 인증 없이 전체 공개로 변경되었으며, 수정/삭제는 소유자 검증이 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->