### PR TITLE
feat: 토큰 재발급 API 구현 및 로그인 응답 포맷 변경

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/AuthController.java
+++ b/src/main/java/com/YOGIITSU/controller/AuthController.java
@@ -1,0 +1,82 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.InvalidTokenException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.MissingTokenException;
+import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
+import com.YOGIITSU.jwt.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "인증 관련 API", description = "토큰 재발급, 인증 관련 기능 제공")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Operation(
+		summary = "토큰 재발급",
+		description = """
+			만료된 AccessToken과 유효한 RefreshToken을 이용하여 새 AccessToken과 RefreshToken을 재발급합니다.  
+						
+			Swagger 사용 시:
+			- 위쪽 Authorize 버튼 클릭 → Bearer {AccessToken} 입력  
+			- 아래 요청 파라미터는 **비워두세요**  
+			- X-Refresh-Token은 Headers 항목에 직접 추가하세요  
+						
+			응답:
+			- 새 AccessToken은 Authorization 헤더로 전달  
+			- 새 RefreshToken은 X-Refresh-Token 헤더로 전달
+			""",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "토큰 재발급 성공",
+				headers = {
+					@Header(name = "Authorization", description = "Bearer {new AccessToken}"),
+					@Header(name = "X-Refresh-Token", description = "{new RefreshToken}")
+				}
+			),
+			@ApiResponse(responseCode = "400", description = "토큰 누락 또는 유효하지 않음")
+		}
+	)
+	@PostMapping("/reissue")
+	public ResponseEntity<Map<String, String>> reissue(
+		@Parameter(hidden = true)
+		@RequestHeader(value = "Authorization", required = false) String accessTokenHeader,
+
+		@Parameter(description = "RefreshToken은 반드시 X-Refresh-Token 헤더에 넣어주세요. <br> 예시: eyJhbGciOiJIUzI1NiJ9...", required = true)
+		@RequestHeader(value = "X-Refresh-Token", required = false) String refreshToken
+	) {
+		if (accessTokenHeader == null || refreshToken == null) {
+			throw new MissingTokenException();
+		}
+
+		String accessToken = accessTokenHeader.replace("Bearer ", "");
+
+		if (!jwtTokenProvider.validateToken(refreshToken)) {
+			throw new InvalidTokenException();
+		}
+
+		Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+		TokenResponseDto newTokens = jwtTokenProvider.generateToken(authentication);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "Bearer " + newTokens.getAccessToken());
+		headers.set("X-Refresh-Token", newTokens.getRefreshToken());
+
+		return ResponseEntity.ok()
+			.headers(headers)
+			.body(Map.of("message", "토큰이 재발급되었습니다."));
+	}
+}

--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -45,7 +45,7 @@ public class MemberController {
 	 */
 	@Operation(summary = "로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
 	@PostMapping("/login")
-	public ResponseEntity<Map<String, String>> login(
+	public ResponseEntity<Map<String, Object>> login(
 		@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
 		return memberService.login(
 			memberLoginRequestDto.getMemberId(),

--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -45,12 +45,14 @@ public class MemberController {
 	 */
 	@Operation(summary = "로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
 	@PostMapping("/login")
-	public TokenResponseDto login(@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
+	public ResponseEntity<Map<String, String>> login(
+		@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
 		return memberService.login(
 			memberLoginRequestDto.getMemberId(),
 			memberLoginRequestDto.getPassword()
 		);
 	}
+
 
 	/**
 	 * 아이디 찾기 API

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -9,9 +9,11 @@ import com.YOGIITSU.dto.RequestDto.PasswordResetRequestDto;
 import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
 import com.YOGIITSU.entity.EmailMessage;
 import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.jwt.CustomUserDetails;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import com.YOGIITSU.repository.EmailMessageRepository;
 import com.YOGIITSU.repository.MemberRepository;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -46,7 +48,7 @@ public class MemberService {
 	 * @return accessToken은 Authorization 헤더로, refreshToken은 X-Refresh-Token 헤더로 내려보냄
 	 */
 	@Transactional
-	public ResponseEntity<Map<String, String>> login(String memberId, String password) {
+	public ResponseEntity<Map<String, Object>> login(String memberId, String password) {
 		try {
 			// 1. 아이디와 비밀번호로 Authentication 객체 생성
 			Authentication authentication = authenticationManagerBuilder.getObject()
@@ -55,17 +57,25 @@ public class MemberService {
 			// 2. 인증된 정보를 바탕으로 JWT 토큰 생성
 			TokenResponseDto tokenInfo = jwtTokenProvider.generateToken(authentication);
 
+			CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+			Long userId = userDetails.getId();
+			String role = userDetails.getRole();
+
 			// 3. 생성된 토큰을 헤더에 담아 반환
 			HttpHeaders headers = new HttpHeaders();
 			headers.set("Authorization", "Bearer " + tokenInfo.getAccessToken());   // AccessToken → Authorization 헤더
 			headers.set("X-Refresh-Token", tokenInfo.getRefreshToken());           // RefreshToken → X-Refresh-Token 헤더
 
+			Map<String, Object> responseBody = new HashMap<>();
+			responseBody.put("message", "로그인 성공");
+			responseBody.put("userId", userId);
+			responseBody.put("role", role);
+
 			return ResponseEntity.ok()
 				.headers(headers)
-				.body(Map.of("message", "로그인 성공"));
+				.body(responseBody);
 
 		} catch (BadCredentialsException e) {
-			// 4. 인증 실패 시 커스텀 예외 던짐
 			throw new InvalidLoginException();
 		}
 	}

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -7,13 +7,15 @@ import com.YOGIITSU.config.handler.GlobalExceptionHandler.PasswordMismatchExcept
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.PasswordNotEqualsException;
 import com.YOGIITSU.dto.RequestDto.PasswordResetRequestDto;
 import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
-import com.YOGIITSU.dto.ResponseDto.UserResponseDto;
 import com.YOGIITSU.entity.EmailMessage;
 import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import com.YOGIITSU.repository.EmailMessageRepository;
 import com.YOGIITSU.repository.MemberRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -41,45 +43,29 @@ public class MemberService {
 	 *
 	 * @param memberId 사용자의 아이디
 	 * @param password 사용자의 비밀번호
-	 * @return TokenResponse JWT 토큰 정보
+	 * @return accessToken은 Authorization 헤더로, refreshToken은 X-Refresh-Token 헤더로 내려보냄
 	 */
 	@Transactional
-	public TokenResponseDto login(String memberId, String password) {
-		// 1. 아이디와 비밀번호를 기반으로 Authentication 객체 생성
-		UsernamePasswordAuthenticationToken authenticationToken =
-			new UsernamePasswordAuthenticationToken(memberId, password);
-
+	public ResponseEntity<Map<String, String>> login(String memberId, String password) {
 		try {
-			// 2. 실제 검증 (사용자 비밀번호 체크)이 이루어지는 부분
+			// 1. 아이디와 비밀번호로 Authentication 객체 생성
 			Authentication authentication = authenticationManagerBuilder.getObject()
-				.authenticate(authenticationToken);
+				.authenticate(new UsernamePasswordAuthenticationToken(memberId, password));
 
-			// 3. 토큰 생성
+			// 2. 인증된 정보를 바탕으로 JWT 토큰 생성
 			TokenResponseDto tokenInfo = jwtTokenProvider.generateToken(authentication);
 
-			// 4. 사용자 정보 조회
-			Member member = memberRepository.findByMemberId(memberId)
-				.orElseThrow(MemberNotFoundException::new);
+			// 3. 생성된 토큰을 헤더에 담아 반환
+			HttpHeaders headers = new HttpHeaders();
+			headers.set("Authorization", "Bearer " + tokenInfo.getAccessToken());   // AccessToken → Authorization 헤더
+			headers.set("X-Refresh-Token", tokenInfo.getRefreshToken());           // RefreshToken → X-Refresh-Token 헤더
 
-			// 5. 사용자 정보 DTO 생성
-			UserResponseDto userDto = UserResponseDto.builder()
-				.id(member.getId())
-				.username(member.getUserName())
-				.memberId(member.getMemberId())
-				.email(member.getEmail())
-				.role(member.getRole()) // role 추가
-				.build();
-
-			// 6. 사용자 정보 포함해서 반환
-			return TokenResponseDto.builder()
-				.grantType("Bearer")
-				.accessToken(tokenInfo.getAccessToken())
-				.refreshToken(tokenInfo.getRefreshToken())
-				.user(userDto)
-				.build();
+			return ResponseEntity.ok()
+				.headers(headers)
+				.body(Map.of("message", "로그인 성공"));
 
 		} catch (BadCredentialsException e) {
-			// 4. 인증 실패 시 예외 처리
+			// 4. 인증 실패 시 커스텀 예외 던짐
 			throw new InvalidLoginException();
 		}
 	}

--- a/src/test/java/com/YOGIITSU/controller/AuthControllerTest.java
+++ b/src/test/java/com/YOGIITSU/controller/AuthControllerTest.java
@@ -1,0 +1,77 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.InvalidTokenException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.MissingTokenException;
+import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
+import com.YOGIITSU.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+	@InjectMocks
+	private AuthController authController;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private Authentication authentication;
+
+	@Test
+	@DisplayName("재발급_성공")
+	void reissue_success() {
+		// given
+		String accessTokenHeader = "Bearer oldAccess";
+		String refreshToken = "validRefresh";
+
+		when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+		when(jwtTokenProvider.getAuthentication("oldAccess")).thenReturn(authentication);
+		when(jwtTokenProvider.generateToken(authentication)).thenReturn(
+			TokenResponseDto.builder()
+				.accessToken("newAccess")
+				.refreshToken("newRefresh")
+				.build()
+		);
+
+		ResponseEntity<Map<String, String>> response = authController.reissue(accessTokenHeader,
+			refreshToken);
+
+		// then
+		assertEquals("토큰이 재발급되었습니다.", response.getBody().get("message"));
+		assertEquals("Bearer newAccess", response.getHeaders().getFirst("Authorization"));
+		assertEquals("newRefresh", response.getHeaders().getFirst("X-Refresh-Token"));
+	}
+
+
+	@Test
+	@DisplayName("재발급_실패_토큰없음")
+	void reissue_missing_token() {
+		assertThrows(MissingTokenException.class, () ->
+			authController.reissue(null, null));
+	}
+
+
+	@Test
+	@DisplayName("재발급_실패_리프레시토큰_유효X")
+	void reissue_invalid_refresh() {
+		// given
+		when(jwtTokenProvider.validateToken("validRefresh")).thenReturn(false);
+
+		// then
+		assertThrows(InvalidTokenException.class, () ->
+			authController.reissue("Bearer oldAccess", "validRefresh"));
+	}
+}

--- a/src/test/java/com/YOGIITSU/service/MemberServiceTest.java
+++ b/src/test/java/com/YOGIITSU/service/MemberServiceTest.java
@@ -1,0 +1,84 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.InvalidLoginException;
+import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
+import com.YOGIITSU.jwt.CustomUserDetails;
+import com.YOGIITSU.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+	@Mock
+	private AuthenticationManagerBuilder authenticationManagerBuilder;
+	@Mock
+	private AuthenticationManager authenticationManager;
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+	@Mock
+	private Authentication authentication;
+
+	@InjectMocks
+	private MemberService memberService;
+
+	@DisplayName("로그인_성공")
+	@Test
+	void login_success() {
+		// given
+		String memberId = "user1";
+		String password = "pass1";
+
+		List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+		CustomUserDetails userDetails = new CustomUserDetails(
+			1L, memberId, "박소미", "test@email.com", "", "USER", authorities
+		);
+
+		when(authenticationManagerBuilder.getObject()).thenReturn(authenticationManager);
+		when(authenticationManager.authenticate(any())).thenReturn(authentication);
+		when(authentication.getPrincipal()).thenReturn(userDetails);
+		when(jwtTokenProvider.generateToken(any())).thenReturn(
+			TokenResponseDto.builder()
+				.accessToken("access")
+				.refreshToken("refresh")
+				.build()
+		);
+
+		// when
+		ResponseEntity<Map<String, Object>> response = memberService.login(memberId, password);
+
+		// then
+		assertEquals("로그인 성공", response.getBody().get("message"));
+		assertEquals(1L, response.getBody().get("userId"));
+		assertEquals("USER", response.getBody().get("role"));
+	}
+
+	@DisplayName("로그인_실패")
+	@Test
+	void login_fail_invalid() {
+		// given
+		when(authenticationManagerBuilder.getObject()).thenReturn(authenticationManager);
+		when(authenticationManager.authenticate(any()))
+			.thenThrow(new BadCredentialsException("잘못된 비밀번호"));
+
+		// then
+		assertThrows(InvalidLoginException.class, () ->
+			memberService.login("wrong", "wrong"));
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`refactor/jwt-util` → `develop`

### 변경 사항
- `/auth/reissue` 토큰 재발급 API 구현

- `MemberService` 리팩토링: 토큰 생성 및 사용자 정보 응답 형식 개선
- `AuthControllerTest`: 토큰 재발급 성공 및 예외 테스트 케이스 추가
- `MemberServiceTest`: 로그인 성공/실패 유닛 테스트 추가
- 로그인 시 응답 구조 변경: `accessToken`, `refreshToken`은 헤더로, `userId`, `role`, `message`는 바디로 분리

### 테스트 결과
- `MemberServiceTest`
    - 로그인 성공 테스트 통과
    - 로그인 실패 (잘못된 비밀번호) 테스트 통과
    
- `AuthControllerTest`
    - 토큰 재발급 성공 테스트 통과
    - 토큰 누락 및 리프레시 토큰 유효성 실패 케이스 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 토큰 재발급을 위한 인증 API 엔드포인트가 추가되었습니다.
- **버그 수정**
  - 로그인 API의 응답 형식이 변경되어, 토큰과 사용자 정보가 헤더와 본문에 포함되어 반환됩니다.
- **테스트**
  - 토큰 재발급 및 로그인 기능에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->