### PR TITLE
feat: 건물 상세정보 반환값에 정렬 기능 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/converter/BuildingConverter.java
+++ b/src/main/java/com/YOGIITSU/converter/BuildingConverter.java
@@ -2,9 +2,10 @@ package com.YOGIITSU.converter;
 
 import com.YOGIITSU.dto.ResponseDto.*;
 import com.YOGIITSU.entity.*;
-import java.util.ArrayList;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,11 +41,15 @@ public class BuildingConverter {
 			.name(building.getName())
 			.tags(building.getBuildingTags().stream()
 				.map(BuildingTag::getName)
+				.sorted()
 				.collect(Collectors.toList()))
 			.imageUrl(building.getImageUrl())
 			.latitude(building.getLatitude())
 			.longitude(building.getLongitude())
 			.facilities(building.getBuildingFacilities().stream()
+				.sorted(Comparator.comparing(BuildingFacility::getFloor,
+						Comparator.nullsLast(String::compareTo))
+					.thenComparing(BuildingFacility::getName))
 				.map(facility -> FacilityResponseDto.builder()
 					.name(facility.getName())
 					.floor(facility.getFloor())
@@ -62,6 +67,7 @@ public class BuildingConverter {
 	private List<DepartmentResponseDto> convertToDepartmentResponseDtos(
 		List<Department> departments) {
 		return departments.stream()
+			.sorted(Comparator.comparing(Department::getId))
 			.map(department -> DepartmentResponseDto.builder()
 				.id(department.getId())
 				.collegeName(department.getCollegeName())
@@ -83,6 +89,7 @@ public class BuildingConverter {
 	private List<FloorImageResponseDto> convertToFloorPlanResponseDtos(
 		List<BuildingFloorImage> floorImages) {
 		return floorImages.stream()
+			.sorted(Comparator.comparing(BuildingFloorImage::getFloor))
 			.map(floorImage -> FloorImageResponseDto.builder()
 				.floor(floorImage.getFloor())
 				.imageUrl(floorImage.getImageUrl())

--- a/src/main/java/com/YOGIITSU/entity/Building.java
+++ b/src/main/java/com/YOGIITSU/entity/Building.java
@@ -33,18 +33,22 @@ public class Building {
 	@Column(name = "image_url")
 	private String imageUrl;
 
+	@Builder.Default
 	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
 	private Set<BuildingFacility> buildingFacilities = new HashSet<>();
 
+	@Builder.Default
 	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
 	private Set<BuildingFloorImage> buildingFloorImages = new HashSet<>();
 
+	@Builder.Default
 	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
 	private Set<BuildingTag> buildingTags = new HashSet<>();
 
+	@Builder.Default
 	@OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
 	private Set<Department> departments = new HashSet<>();

--- a/src/main/java/com/YOGIITSU/entity/BuildingFacility.java
+++ b/src/main/java/com/YOGIITSU/entity/BuildingFacility.java
@@ -3,11 +3,13 @@ package com.YOGIITSU.entity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "building_facilities")

--- a/src/main/java/com/YOGIITSU/entity/BuildingTag.java
+++ b/src/main/java/com/YOGIITSU/entity/BuildingTag.java
@@ -3,11 +3,13 @@ package com.YOGIITSU.entity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "building_tag")

--- a/src/main/java/com/YOGIITSU/entity/Department.java
+++ b/src/main/java/com/YOGIITSU/entity/Department.java
@@ -2,12 +2,16 @@ package com.YOGIITSU.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "departments")
 public class Department {
 

--- a/src/test/java/com/YOGIITSU/converter/BuildingConverterTest.java
+++ b/src/test/java/com/YOGIITSU/converter/BuildingConverterTest.java
@@ -1,0 +1,133 @@
+package com.YOGIITSU.converter;
+
+import com.YOGIITSU.dto.ResponseDto.BuildingDetailResponseDto;
+import com.YOGIITSU.dto.ResponseDto.DepartmentResponseDto;
+import com.YOGIITSU.dto.ResponseDto.FloorImageResponseDto;
+import com.YOGIITSU.entity.Building;
+import com.YOGIITSU.entity.BuildingFacility;
+import com.YOGIITSU.entity.BuildingFloorImage;
+import com.YOGIITSU.entity.BuildingTag;
+import com.YOGIITSU.entity.Department;
+import java.util.HashSet;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BuildingConverterTest {
+
+	private final BuildingConverter converter = new BuildingConverter();
+
+	@Test
+	@DisplayName("departments는 id 기준으로 정렬되어 반환된다")
+	void convertToBuildingDetailResponseDto_departmentsSortedById() {
+		// given
+		Department d1 = Department.builder().id(3L).departmentName("A학과").build();
+		Department d2 = Department.builder().id(1L).departmentName("B학과").build();
+		Department d3 = Department.builder().id(2L).departmentName("C학과").build();
+		Set<Department> unorderedDepartments = new LinkedHashSet<>(List.of(d1, d2, d3));
+
+		Building building = Building.builder()
+			.name("지능형SW융합대학")
+			.departments(unorderedDepartments)
+			.buildingTags(new HashSet<>())
+			.buildingFacilities(new HashSet<>())
+			.buildingFloorImages(new HashSet<>())
+			.build();
+
+		// when
+		BuildingDetailResponseDto dto = converter.convertToBuildingDetailResponseDto(building,
+			false);
+		List<DepartmentResponseDto> result = dto.getDepartments();
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getId()).isEqualTo(1L);
+		assertThat(result.get(1).getId()).isEqualTo(2L);
+		assertThat(result.get(2).getId()).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("tags는 알파벳/한글 오름차순으로 정렬되어 반환된다")
+	void convertToBuildingDetailResponseDto_tagsSortedAlphabetically() {
+		// given
+		Building building = Building.builder()
+			.name("지능형SW융합대학")
+			.departments(new HashSet<>())
+			.buildingTags(Set.of(
+				BuildingTag.builder().id(1L).name("ICT융합대학").build(),
+				BuildingTag.builder().id(2L).name("벨칸토아트센터").build(),
+				BuildingTag.builder().id(3L).name("IT대학").build()
+			))
+			.buildingFacilities(new HashSet<>())
+			.buildingFloorImages(new HashSet<>())
+			.build();
+
+		// when
+		BuildingDetailResponseDto dto = converter.convertToBuildingDetailResponseDto(building,
+			false);
+		List<String> result = dto.getBuildingInfo().getTags();
+
+		// then
+		assertThat(result).containsExactly("ICT융합대학", "IT대학", "벨칸토아트센터");
+	}
+
+	@Test
+	@DisplayName("facilities는 floor 우선, 같은 층 내에서는 name 기준으로 정렬된다")
+	void convertToBuildingDetailResponseDto_facilitiesSortedByFloorAndName() {
+		// given
+		Building building = Building.builder()
+			.name("지능형SW융합대학")
+			.departments(new HashSet<>())
+			.buildingTags(new HashSet<>())
+			.buildingFacilities(Set.of(
+				BuildingFacility.builder().id(1L).floor("2층").name("랩실").build(),
+				BuildingFacility.builder().id(2L).floor("1층").name("강의실").build(),
+				BuildingFacility.builder().id(3L).floor("1층").name("휴게실").build()
+			))
+
+			.buildingFloorImages(new HashSet<>())
+			.build();
+
+		// when
+		BuildingDetailResponseDto dto = converter.convertToBuildingDetailResponseDto(building,
+			false);
+		List<String> result = dto.getBuildingInfo().getFacilities().stream()
+			.map(f -> f.getFloor() + "-" + f.getName())
+			.toList();
+
+		// then
+		assertThat(result).containsExactly("1층-강의실", "1층-휴게실", "2층-랩실");
+	}
+
+	@Test
+	@DisplayName("floorPlans는 floor 기준으로 오름차순 정렬되어 반환된다")
+	void convertToBuildingDetailResponseDto_floorPlansSortedByFloor() {
+		// given
+		Building building = Building.builder()
+			.name("지능형SW융합대학")
+			.departments(new HashSet<>())
+			.buildingTags(new HashSet<>())
+			.buildingFacilities(new HashSet<>())
+			.buildingFloorImages(Set.of(
+				new BuildingFloorImage(1L, null, "3층", "3층.png"),
+				new BuildingFloorImage(2L, null, "1층", "1층.png"),
+				new BuildingFloorImage(3L, null, "2층", "2층.png")
+			))
+			.build();
+
+		// when
+		BuildingDetailResponseDto dto = converter.convertToBuildingDetailResponseDto(building,
+			false);
+		List<String> result = dto.getFloorPlans().stream()
+			.map(FloorImageResponseDto::getFloor)
+			.toList();
+
+		// then
+		assertThat(result).containsExactly("1층", "2층", "3층");
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/building` → `develop`

### 변경 사항
- `BuildingConverter` 내부 정렬 로직 적용

    - departments: `id` 기준 오름차순 정렬
    - tags: 알파벳/한글 순 정렬
    - facilities: `floor` 정렬 후 같은 층일 경우 `name` 기준 정렬
    - floorPlans: `floor` 기준 정렬
- `Building` 엔티티에 `@Builder.Default` 추가 → builder 사용 시 NPE 방지
- 테스트 코드 추가
    - `departments`, `tags`, `facilities`, `floorPlans` 정렬 검증

### 테스트 결과

- 테스트 4건 모두 통과 (`BuildingConverterTest`)
    - 정렬 순서가 의도대로 응답에 반영되는지 검증 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 엔터티 클래스에 빌더 패턴과 관련된 Lombok 어노테이션이 추가되어 객체 생성이 더욱 간편해졌습니다.

- **버그 수정**
  - 건물 관련 정보 변환 시, 부서, 태그, 시설, 층 이미지 목록이 지정된 기준(이름, ID, 층 등)에 따라 정렬되어 일관된 순서로 표시됩니다.

- **테스트**
  - 컬렉션 정렬 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->