### PR TITLE
feat: 회원 탈퇴 시 작성한 문의 자동 삭제 및 단위 테스트 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/entity/Member.java
+++ b/src/main/java/com/YOGIITSU/entity/Member.java
@@ -44,6 +44,9 @@ public class Member implements UserDetails {
 	@Column(name = "join_at", nullable = false)
 	private LocalDateTime joinAt; // 가입일
 
+	@OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
+	private List<Inquiry> inquiries;
+
 	// UserDetails 인터페이스 구현 메서드들
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/test/java/com/YOGIITSU/service/MemberServiceTest.java
+++ b/src/test/java/com/YOGIITSU/service/MemberServiceTest.java
@@ -1,9 +1,12 @@
 package com.YOGIITSU.service;
 
+import com.YOGIITSU.config.handler.GlobalExceptionHandler;
 import com.YOGIITSU.config.handler.GlobalExceptionHandler.InvalidLoginException;
 import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
+import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.jwt.CustomUserDetails;
 import com.YOGIITSU.jwt.JwtTokenProvider;
+import com.YOGIITSU.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +21,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.List;
 import java.util.Map;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -33,6 +37,11 @@ class MemberServiceTest {
 	private JwtTokenProvider jwtTokenProvider;
 	@Mock
 	private Authentication authentication;
+
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private PasswordEncoder passwordEncoder;
 
 	@InjectMocks
 	private MemberService memberService;
@@ -80,5 +89,57 @@ class MemberServiceTest {
 		// then
 		assertThrows(InvalidLoginException.class, () ->
 			memberService.login("wrong", "wrong"));
+	}
+
+	@DisplayName("회원 탈퇴 성공")
+	@Test
+	void deleteMember_success() {
+		// given
+		String memberId = "user123";
+		String rawPassword = "password123";
+		String encodedPassword = "encoded123";
+
+		Member member = Member.builder()
+			.id(1L)
+			.memberId(memberId)
+			.password(encodedPassword)
+			.email("test@email.com")
+			.userName("테스트유저")
+			.role("USER")
+			.joinAt(java.time.LocalDateTime.now())
+			.build();
+
+		when(memberRepository.findByMemberId(memberId)).thenReturn(java.util.Optional.of(member));
+		when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+		when(memberRepository.existsByMemberId(memberId)).thenReturn(false); // 삭제 이후 체크
+
+		// when
+		memberService.deleteMember(memberId, rawPassword);
+
+		// then
+		verify(memberRepository).delete(member);
+		verify(memberRepository).existsByMemberId(memberId);
+	}
+
+	@DisplayName("회원 탈퇴 실패 - 비밀번호 불일치")
+	@Test
+	void deleteMember_fail_wrongPassword() {
+		// given
+		String memberId = "user123";
+		String rawPassword = "wrongPass";
+
+		Member member = Member.builder()
+			.id(1L)
+			.memberId(memberId)
+			.password("encoded123")
+			.build();
+
+		when(memberRepository.findByMemberId(memberId)).thenReturn(java.util.Optional.of(member));
+		when(passwordEncoder.matches(rawPassword, "encoded123")).thenReturn(false);
+
+		// then
+		assertThrows(GlobalExceptionHandler.PasswordMismatchException.class, () ->
+			memberService.deleteMember(memberId, rawPassword)
+		);
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/delete-account` → `develop`

### 변경 사항

- `Member` 엔티티에 `List<Inquiry> inquiries` 필드 추가 및 연관 관계 설정
    
    → `@OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)` 적용
    
    → 회원 탈퇴 시 작성한 문의가 함께 삭제되도록 처리
    
- `MemberServiceTest`에 회원 탈퇴 기능 단위 테스트 추가
    - 정상 탈퇴 시 `delete()` 호출 여부 검증
    - 비밀번호 불일치 시 예외 발생 여부 확인

### 테스트 결과

- `MemberService.deleteMember()` 호출 시 `memberRepository.delete()` 정상 호출됨 확인

- 회원 삭제 후 `existsByMemberId()` 결과 false 확인
- 비밀번호 불일치 시 `PasswordMismatchException` 발생 확인