### PR TITLE
feat: 시설 마커 API 구현 및 서비스 단위 테스트 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/FacilityMarkerController.java
+++ b/src/main/java/com/YOGIITSU/controller/FacilityMarkerController.java
@@ -31,7 +31,7 @@ public class FacilityMarkerController {
 	@GetMapping
 	public List<FacilityMarkerResponseDto> getMarkersByType(
 		@Parameter(
-			description = "시설 유형 (RESTAURANT: 식당, PARKING: 주차장, CONVENIENCE_CAFE: 카페 및 편의점)",
+			description = "시설 유형 (RESTAURANT: 식당, PARKING: 주차장, CONVENIENCE_CAFE: 카페 및 편의점, SHUTTLE_BUS: 셔틀버스 정류장)",
 			example = "PARKING",
 			required = true
 		)

--- a/src/main/java/com/YOGIITSU/controller/FacilityMarkerController.java
+++ b/src/main/java/com/YOGIITSU/controller/FacilityMarkerController.java
@@ -1,0 +1,42 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.dto.ResponseDto.FacilityMarkerResponseDto;
+import com.YOGIITSU.enums.FacilityType;
+import com.YOGIITSU.service.FacilityMarkerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 시설 마커 관련 API를 제공하는 컨트롤러입니다. 예: 주차장, 카페, 식당 등의 위치 정보 조회
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/facilities")
+@Tag(name = "시설 마커 API", description = "지도에 표시할 주차장, 카페, 식당 등의 위치 데이터를 조회하는 기능을 제공합니다.")
+public class FacilityMarkerController {
+
+	private final FacilityMarkerService facilityMarkerService;
+
+	@Operation(
+		summary = "시설 마커 위치 조회",
+		description = "시설 유형(FacilityType)을 기준으로 해당 위치들의 위도(latitude)와 경도(longitude)를 반환합니다."
+	)
+	@GetMapping
+	public List<FacilityMarkerResponseDto> getMarkersByType(
+		@Parameter(
+			description = "시설 유형 (RESTAURANT: 식당, PARKING: 주차장, CONVENIENCE_CAFE: 카페 및 편의점)",
+			example = "PARKING",
+			required = true
+		)
+		@RequestParam(name = "type", required = true) FacilityType type
+	) {
+		return facilityMarkerService.getMarkersByType(type);
+	}
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/FacilityMarkerResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/FacilityMarkerResponseDto.java
@@ -1,0 +1,13 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FacilityMarkerResponseDto {
+
+	private String name;
+	private Double latitude;
+	private Double longitude;
+}

--- a/src/main/java/com/YOGIITSU/entity/FacilityMarker.java
+++ b/src/main/java/com/YOGIITSU/entity/FacilityMarker.java
@@ -1,0 +1,28 @@
+package com.YOGIITSU.entity;
+
+import com.YOGIITSU.enums.FacilityType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "facility_marker")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FacilityMarker {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "place_name")
+	private String placeName;
+
+	@Enumerated(EnumType.STRING)
+	private FacilityType type;
+
+	private Double latitude;
+
+	private Double longitude;
+}

--- a/src/main/java/com/YOGIITSU/enums/FacilityType.java
+++ b/src/main/java/com/YOGIITSU/enums/FacilityType.java
@@ -1,0 +1,7 @@
+package com.YOGIITSU.enums;
+
+public enum FacilityType {
+	RESTAURANT,
+	PARKING,
+	CONVENIENCE_CAFE
+}

--- a/src/main/java/com/YOGIITSU/enums/FacilityType.java
+++ b/src/main/java/com/YOGIITSU/enums/FacilityType.java
@@ -3,5 +3,6 @@ package com.YOGIITSU.enums;
 public enum FacilityType {
 	RESTAURANT,
 	PARKING,
-	CONVENIENCE_CAFE
+	CONVENIENCE_CAFE,
+	SHUTTLE_BUS
 }

--- a/src/main/java/com/YOGIITSU/repository/FacilityMarkerRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/FacilityMarkerRepository.java
@@ -1,0 +1,11 @@
+package com.YOGIITSU.repository;
+
+import com.YOGIITSU.entity.FacilityMarker;
+import com.YOGIITSU.enums.FacilityType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacilityMarkerRepository extends JpaRepository<FacilityMarker, Long> {
+
+	List<FacilityMarker> findByType(FacilityType type);
+}

--- a/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
+++ b/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
@@ -1,0 +1,35 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.dto.ResponseDto.FacilityMarkerResponseDto;
+import com.YOGIITSU.enums.FacilityType;
+import com.YOGIITSU.repository.FacilityMarkerRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 시설 마커 관련 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Service
+@RequiredArgsConstructor
+public class FacilityMarkerService {
+
+	// 시설 마커 정보를 조회하는 JPA Repository
+	private final FacilityMarkerRepository facilityMarkerRepository;
+
+	/**
+	 * 특정 시설 유형(FacilityType)에 해당하는 마커 리스트를 조회
+	 *
+	 * @param type 조회할 시설 유형 (예: RESTAURANT, PARKING, CONVENIENCE_CAFE)
+	 * @return FacilityMarkerResponseDto
+	 */
+	public List<FacilityMarkerResponseDto> getMarkersByType(FacilityType type) {
+		return facilityMarkerRepository.findByType(type).stream()
+			.map(f -> new FacilityMarkerResponseDto(
+				f.getPlaceName(),
+				f.getLatitude(),
+				f.getLongitude()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
+++ b/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
@@ -25,6 +25,9 @@ public class FacilityMarkerService {
 	 * @return FacilityMarkerResponseDto
 	 */
 	public List<FacilityMarkerResponseDto> getMarkersByType(FacilityType type) {
+		if (type == null) {
+			throw new IllegalArgumentException("시설 유형은 필수값입니다.");
+		}
 		return facilityMarkerRepository.findByType(type).stream()
 			.map(f -> new FacilityMarkerResponseDto(
 				f.getPlaceName(),

--- a/src/test/java/com/YOGIITSU/service/FacilityMarkerServiceTest.java
+++ b/src/test/java/com/YOGIITSU/service/FacilityMarkerServiceTest.java
@@ -72,18 +72,13 @@ class FacilityMarkerServiceTest {
 		assertTrue(result.isEmpty());
 	}
 
-	@DisplayName("시설유형_null_예외없음_빈리스트반환")
+	@DisplayName("시설유형_null_예외발생")
 	@Test
-	void getMarkersByType_nullType() {
-		// given
-		when(facilityMarkerRepository.findByType(null)).thenReturn(Collections.emptyList());
-
-		// when
-		List<FacilityMarkerResponseDto> result = facilityMarkerService.getMarkersByType(null);
-
-		// then
-		assertNotNull(result);
-		assertTrue(result.isEmpty());
+	void getMarkersByType_nullType_throwsException() {
+		// given & when & then
+		assertThrows(IllegalArgumentException.class, () -> {
+			facilityMarkerService.getMarkersByType(null);
+		});
 	}
 
 	@DisplayName("시설유형_중복마커_정상반환")

--- a/src/test/java/com/YOGIITSU/service/FacilityMarkerServiceTest.java
+++ b/src/test/java/com/YOGIITSU/service/FacilityMarkerServiceTest.java
@@ -1,0 +1,119 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.dto.ResponseDto.FacilityMarkerResponseDto;
+import com.YOGIITSU.entity.FacilityMarker;
+import com.YOGIITSU.enums.FacilityType;
+import com.YOGIITSU.repository.FacilityMarkerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class FacilityMarkerServiceTest {
+
+	@Mock
+	private FacilityMarkerRepository facilityMarkerRepository;
+
+	@InjectMocks
+	private FacilityMarkerService facilityMarkerService;
+
+	@DisplayName("시설유형_마커조회_성공")
+	@Test
+	void getMarkersByType_success() {
+		// given
+		FacilityType type = FacilityType.CONVENIENCE_CAFE;
+
+		FacilityMarker marker1 = FacilityMarker.builder()
+			.placeName("종강 카페")
+			.latitude(37.2093280)
+			.longitude(126.978640)
+			.type(type)
+			.build();
+
+		FacilityMarker marker2 = FacilityMarker.builder()
+			.placeName("인문대 CU")
+			.latitude(37.2113740)
+			.longitude(126.979640)
+			.type(type)
+			.build();
+
+		when(facilityMarkerRepository.findByType(type)).thenReturn(List.of(marker1, marker2));
+
+		// when
+		List<FacilityMarkerResponseDto> result = facilityMarkerService.getMarkersByType(type);
+
+		// then
+		assertEquals(2, result.size());
+		assertEquals("종강 카페", result.get(0).getName());
+		assertEquals(126.979640, result.get(1).getLongitude());
+	}
+
+	@DisplayName("시설유형_마커없음_빈리스트반환")
+	@Test
+	void getMarkersByType_emptyList() {
+		// given
+		FacilityType type = FacilityType.RESTAURANT;
+		when(facilityMarkerRepository.findByType(type)).thenReturn(Collections.emptyList());
+
+		// when
+		List<FacilityMarkerResponseDto> result = facilityMarkerService.getMarkersByType(type);
+
+		// then
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+	@DisplayName("시설유형_null_예외없음_빈리스트반환")
+	@Test
+	void getMarkersByType_nullType() {
+		// given
+		when(facilityMarkerRepository.findByType(null)).thenReturn(Collections.emptyList());
+
+		// when
+		List<FacilityMarkerResponseDto> result = facilityMarkerService.getMarkersByType(null);
+
+		// then
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+	@DisplayName("시설유형_중복마커_정상반환")
+	@Test
+	void getMarkersByType_duplicateMarkers() {
+		// given
+		FacilityType type = FacilityType.PARKING;
+
+		FacilityMarker marker1 = FacilityMarker.builder()
+			.placeName("음대 주차장")
+			.latitude(37.210000)
+			.longitude(126.970000)
+			.type(type)
+			.build();
+
+		FacilityMarker marker2 = FacilityMarker.builder()
+			.placeName("음대 주차장") // 중복 이름
+			.latitude(37.210001)
+			.longitude(126.970001)
+			.type(type)
+			.build();
+
+		when(facilityMarkerRepository.findByType(type)).thenReturn(List.of(marker1, marker2));
+
+		// when
+		List<FacilityMarkerResponseDto> result = facilityMarkerService.getMarkersByType(type);
+
+		// then
+		assertEquals(2, result.size());
+		assertEquals("음대 주차장", result.get(0).getName());
+		assertEquals("음대 주차장", result.get(1).getName());
+	}
+}

--- a/src/test/java/com/YOGIITSU/service/FacilityMarkerServiceTest.java
+++ b/src/test/java/com/YOGIITSU/service/FacilityMarkerServiceTest.java
@@ -53,7 +53,15 @@ class FacilityMarkerServiceTest {
 
 		// then
 		assertEquals(2, result.size());
+
+		// 첫 번째 마커 검증
 		assertEquals("종강 카페", result.get(0).getName());
+		assertEquals(37.2093280, result.get(0).getLatitude());
+		assertEquals(126.978640, result.get(0).getLongitude());
+
+		// 두 번째 마커 검증
+		assertEquals("인문대 CU", result.get(1).getName());
+		assertEquals(37.2113740, result.get(1).getLatitude());
 		assertEquals(126.979640, result.get(1).getLongitude());
 	}
 

--- a/src/test/java/com/YOGIITSU/service/FacilityMarkerServiceTest.java
+++ b/src/test/java/com/YOGIITSU/service/FacilityMarkerServiceTest.java
@@ -118,5 +118,12 @@ class FacilityMarkerServiceTest {
 		assertEquals(2, result.size());
 		assertEquals("음대 주차장", result.get(0).getName());
 		assertEquals("음대 주차장", result.get(1).getName());
+
+		// 좌표가 다른지 검증 (중복 이름이지만 다른 위치)
+		assertEquals(37.210000, result.get(0).getLatitude());
+		assertEquals(126.970000, result.get(0).getLongitude());
+
+		assertEquals(37.210001, result.get(1).getLatitude());
+		assertEquals(126.970001, result.get(1).getLongitude());
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/facility-marker` → `develop`

### 변경 사항

- `FacilityMarker`, `FacilityType` 엔티티 및 ENUM 생성

- `FacilityMarkerRepository`에 type 기준 조회 메서드 추가
- `FacilityMarkerService` 구현: 시설 유형별 위치 데이터 리스트 반환
- `FacilityMarkerResponseDto` 생성: 마커 이름, 위도, 경도 응답용
- `FacilityMarkerController` 구현 및 Swagger 문서 어노테이션 추가
    - `@RequestParam(required = true)` 명시로 type 필수값 지정
- `FacilityMarkerServiceTest` 단위 테스트 작성 (총 4개 시나리오)
    - 시설유형 정상 조회
    - 마커 없음 (빈 리스트 반환)
    - null 요청 (빈 리스트 반환)
    - 중복 마커 처리 확인

### 테스트 결과
- Swagger UI를 통한 수동 테스트 완료
- `FacilityMarkerServiceTest` 단위 테스트 모두 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 주차장, 카페, 식당, 셔틀버스 정류장 등 시설 정보를 유형별로 조회할 수 있는 API가 추가되었습니다.
    - 각 시설의 이름과 위치(위도, 경도) 정보를 제공합니다.

- **테스트**
    - 다양한 시설 유형과 데이터 상황에 따른 서비스 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->