### PR TITLE
Fix/email change

### DIFF
--- a/src/main/java/com/YOGIITSU/entity/EmailMessage.java
+++ b/src/main/java/com/YOGIITSU/entity/EmailMessage.java
@@ -34,7 +34,7 @@ public class EmailMessage {
     private EmailPurpose purpose;
 
     // 인증 성공 시 승인 처리
-    public void setIsApproved(boolean isApproved) {
-        this.isApproved = isApproved;
+    public void approve() {
+        this.isApproved = true;
     }
 }

--- a/src/main/java/com/YOGIITSU/repository/MemberRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/MemberRepository.java
@@ -1,24 +1,30 @@
 package com.YOGIITSU.repository;
 
 import com.YOGIITSU.entity.Member;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	// MemberId를 기준으로 회원을 찾는 메서드
 	Optional<Member> findByMemberId(String memberId);
 
+	// memberId를 가진 Member 엔티티에 쓰기 잠금을 걸어 동시성 문제를 방지
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT m FROM Member m WHERE m.memberId = :memberId") // memberId로 Member를 조회
+	Optional<Member> findByMemberIdWithLock(@Param("memberId") String memberId);
+
 	// 이메일을 기준으로 회원을 찾는 메서드 추가
 	Optional<Member> findByEmail(String email);
-
-	// MemberId를 기준으로 회원을 삭제하는 메서드 추가
-	void deleteByMemberId(String memberId);
 
 	// MemberId를 기준으로 회원 존재 여부를 확인하는 메서드 추가
 	boolean existsByMemberId(String memberId);
 
-    // userName을 기준으로 이름 중복 여부 확인 메서드
+	// userName을 기준으로 이름 중복 여부 확인 메서드
 	Optional<Member> findByUserName(String userName);
 
 	boolean existsByEmail(String email);

--- a/src/main/java/com/YOGIITSU/service/EmailService.java
+++ b/src/main/java/com/YOGIITSU/service/EmailService.java
@@ -109,6 +109,10 @@ public class EmailService {
 
     // 인증 목적에 따른 이메일 유효성 검사
     public void validateEmailRequest(String email, EmailPurpose purpose, Authentication auth) {
+        if (email == null || email.trim().isEmpty()) {
+            throw new IllegalArgumentException("이메일 주소는 필수입니다.");
+        }
+
         // 인증이 필요한 목적인지 확인
         if (requiresAuthentication(purpose)) {
             checkAuthentication(auth); //목적이 signup인 경우에는 로그인 요청을 강요하면 안됨
@@ -187,7 +191,7 @@ public class EmailService {
 
         // 6. 사용자 이메일 변경
         String memberId = auth.getName();
-        Member member = memberRepository.findByMemberId(memberId)
+        Member member = memberRepository.findByMemberIdWithLock(memberId)
             .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
         member.setEmail(newEmail);
@@ -213,7 +217,7 @@ public class EmailService {
 
     // 인증 승인 처리 및 저장
     private void approveAndSave(EmailMessage message) {
-        message.setIsApproved(true);
+        message.approve();
         emailMessageRepository.save(message);
     }
 

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -179,7 +179,7 @@ public class MemberService {
 		memberRepository.save(member);
 
 		// 6. 인증 상태 초기화 (다시 사용하지 못하게)
-		emailMessage.setIsApproved(false);
+		emailMessage.approve();
 		emailMessageRepository.save(emailMessage);
 	}
 }

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -178,8 +178,7 @@ public class MemberService {
 		member.changePassword(passwordEncoder.encode(requestDto.getNewPassword()));
 		memberRepository.save(member);
 
-		// 6. 인증 상태 초기화 (다시 사용하지 못하게)
-		emailMessage.approve();
-		emailMessageRepository.save(emailMessage);
+		// 6. 사용된 인증 메시지 삭제 (재사용 방지)
+		emailMessageRepository.delete(emailMessage);
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 반영 브랜치
`fix/email-change` → `develop`


### 변경 사항

- **도메인 객체 책임 강화**
  - `EmailMessage` 엔티티에 인증 승인 처리를 위한 `approve()` 메서드를 추가하고, 외부에서의 `setter` 사용을 제거했습니다.
  - 이를 통해 불변성 유지와 응집도 향상을 도모했습니다.

- **동시성 제어를 위한 비관적 락(PESSIMISTIC_WRITE) 적용**
  - 이메일 변경 시 데이터 정합성을 보장하기 위해 `MemberRepository`에 `findByMemberIdWithLock()` 메서드를 추가했습니다.
  - 동시성 문제를 예방하기 위해 비관적 잠금(PESSIMISTIC_WRITE)을 적용했습니다.

- **이메일 인증 검증 로직 개선**
  - 인증 코드 확인 시 `null` 또는 공백 여부를 검증하는 로직을 추가하여, 예외 상황을 방지할 수 있도록 보완했습니다.


### 테스트 결과

- 이메일 변경 및 비밀번호 재설정 기능에서 동작 이상 없음 확인  
- `approve()` 메서드 적용 이후 인증 상태 초기화가 정상적으로 반영됨  
- 동시 요청 발생 시 중복 이메일 저장 없이 안전하게 처리됨  
- 인증되지 않은 사용자, 잘못된 코드, 만료된 코드 등 예외 상황에 대해 정상적인 메시지 반환 및 처리 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 회원 조회 시 동시성 문제를 방지하는 잠금 기능이 추가되었습니다.
- **버그 수정**
	- 이메일 요청 시 이메일 주소가 비어있거나 null인 경우 명확한 오류 메시지가 제공됩니다.
- **기능 개선**
	- 이메일 승인 처리가 더 안전하게 변경되었습니다.
	- 회원 삭제 관련 일부 기능이 제거되었습니다.
	- 비밀번호 재설정 후 이메일 인증 기록이 삭제되도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->