### PR TITLE
feat: 시설 마커에 빌딩 ID 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/FacilityMarkerResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/FacilityMarkerResponseDto.java
@@ -10,4 +10,5 @@ public class FacilityMarkerResponseDto {
 	private String name;
 	private Double latitude;
 	private Double longitude;
+	private Long buildingId;
 }

--- a/src/main/java/com/YOGIITSU/entity/FacilityMarker.java
+++ b/src/main/java/com/YOGIITSU/entity/FacilityMarker.java
@@ -25,4 +25,8 @@ public class FacilityMarker {
 	private Double latitude;
 
 	private Double longitude;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "building_id", nullable = false)
+	private Building building;
 }

--- a/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
+++ b/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
@@ -32,7 +32,9 @@ public class FacilityMarkerService {
 			.map(f -> new FacilityMarkerResponseDto(
 				f.getPlaceName(),
 				f.getLatitude(),
-				f.getLongitude()))
+				f.getLongitude(),
+				f.getBuilding() != null ? f.getBuilding().getId() : null // 빌딩 ID 추가
+			))
 			.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/add-building-id` → `develop`

### 변경 사항
- FacilityMarker 엔티티에 Building 연관관계 추가

- FacilityMarkerResponseDto에 buildingId 필드 추가

- FacilityMarkerService에서 DTO 생성 시 buildingId 포함되도록 수정
### 테스트 결과
- Swagger를 통해 시설 마커 조회 시 buildingId가 포함되어 정상 반환됨
```{
    "name": "체육관 주차장",
    "latitude": 37.212351,
    "longitude": 126.978403,
    "buildingId": 2
  }
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 시설 마커 정보에 건물 ID가 포함되어 제공됩니다. 이제 마커 조회 시 건물 식별 정보를 함께 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->