### PR TITLE
feat: 최근 검색어에 buildingId 매핑 및 응답값 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/RecentSearchResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/RecentSearchResponseDto.java
@@ -12,9 +12,11 @@ public class RecentSearchResponseDto {
 
 	private String keyword;
 	private LocalDateTime searchedAt;
+	private Long buildingId;
 
 	public RecentSearchResponseDto(RecentSearch recentSearch) {
 		this.keyword = recentSearch.getKeyword();
 		this.searchedAt = recentSearch.getSearchedAt();
+		this.buildingId = recentSearch.getBuilding() != null ? recentSearch.getBuilding().getId() : null;
 	}
 }

--- a/src/main/java/com/YOGIITSU/entity/RecentSearch.java
+++ b/src/main/java/com/YOGIITSU/entity/RecentSearch.java
@@ -26,4 +26,8 @@ public class RecentSearch {
 
 	@Column(name = "searched_at", nullable = false)
 	private LocalDateTime searchedAt;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "building_id", nullable = false)
+	private Building building;
 }

--- a/src/main/java/com/YOGIITSU/service/RecentSearchService.java
+++ b/src/main/java/com/YOGIITSU/service/RecentSearchService.java
@@ -1,8 +1,11 @@
 package com.YOGIITSU.service;
 
 import com.YOGIITSU.dto.ResponseDto.RecentSearchResponseDto;
+import com.YOGIITSU.entity.Building;
 import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.entity.BuildingAlias;
 import com.YOGIITSU.entity.RecentSearch;
+import com.YOGIITSU.repository.BuildingAliasRepository;
 import com.YOGIITSU.repository.MemberRepository;
 import com.YOGIITSU.repository.RecentSearchRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -18,6 +21,7 @@ public class RecentSearchService {
 
 	private final RecentSearchRepository recentSearchRepository;
 	private final MemberRepository memberRepository;
+	private final BuildingAliasRepository buildingAliasRepository;
 
 	//최근 검색어 저장
 	@Transactional
@@ -35,11 +39,18 @@ public class RecentSearchService {
 			recentSearchRepository.delete(recentSearches.getLast());
 		}
 
+		// alias 기반으로 building 매핑
+		Building matchedBuilding = buildingAliasRepository.findByAliasContaining(keyword).stream()
+			.map(BuildingAlias::getBuilding)
+			.findFirst()
+			.orElse(null);
+
 		// 새로운 검색어 저장
 		RecentSearch search = RecentSearch.builder()
 			.member(member)
 			.keyword(keyword)
 			.searchedAt(LocalDateTime.now())
+			.building(matchedBuilding)
 			.build();
 		recentSearchRepository.save(search);
 	}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/search` → `develop`

### 변경 사항
- RecentSearch 엔티티에 Building 연관관계 추가 (building_id 외래키)

- 사용자가 검색어 입력 시 BuildingAlias를 기준으로 관련 건물 자동 매핑

- RecentSearchResponseDto에 buildingId 필드 추가
### 테스트 결과
- Swagger에서 /search/recent API 호출 시 buildingId가 포함되어 정상 반환됨

- 검색어 "법정대학" 입력 시 → "사회관" 매핑 → buildingId = 11 저장됨

- DB 확인 결과, recent_search.building_id 컬럼에 값 정상 입력됨
```
  {
    "keyword": "법정대학",
    "searchedAt": "2025-06-27T18:06:19.46581",
    "buildingId": 11
  }
```