### PR TITLE
feat: 검색어 단건 삭제 및 전체 최근 검색어 삭제 API 구현

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/RecentSearchController.java
+++ b/src/main/java/com/YOGIITSU/controller/RecentSearchController.java
@@ -118,4 +118,29 @@ public class RecentSearchController {
 		response.put("message", "해당 건물의 검색어가 삭제되었습니다.");
 		return ResponseEntity.ok(response);
 	}
+
+	/**
+	 * 검색어 전체 삭제 API
+	 *
+	 * @return 전체 검색어 삭제 성공 메시지
+	 */
+	@Operation(summary = "전체 최근 검색어 삭제", description = "모든 최근 검색어를 삭제합니다.")
+	@DeleteMapping("/deleteAll")
+	public ResponseEntity<Map<String, String>> deleteAllKeywords(HttpServletRequest httpRequest) {
+
+		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+		if (accessToken == null) {
+			throw new MissingTokenException();
+		}
+		if (!jwtTokenProvider.validateToken(accessToken)) {
+			throw new InvalidTokenException();
+		}
+
+		String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
+		recentSearchService.deleteAllSearchKeywords(memberId);
+
+		Map<String, String> response = new HashMap<>();
+		response.put("message", "전체 검색어가 삭제되었습니다.");
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/YOGIITSU/controller/RecentSearchController.java
+++ b/src/main/java/com/YOGIITSU/controller/RecentSearchController.java
@@ -7,7 +7,6 @@ import com.YOGIITSU.dto.ResponseDto.RecentSearchResponseDto;
 import com.YOGIITSU.service.RecentSearchService;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -89,5 +88,34 @@ public class RecentSearchController {
 
 		// 3. 최근 검색어 조회 후 반환
 		return ResponseEntity.ok(recentSearchService.getRecentSearches(memberId));
+	}
+
+	/**
+	 * 검색어 단건 삭제 API
+	 *
+	 * @param buildingId 삭제할 검색어가 연결된 건물 ID
+	 * @return 삭제 성공 메시지
+	 */
+
+	@Operation(summary = "최근 검색어 단건 삭제", description = "연결된 건물 ID를 통해 해당 검색어를 삭제합니다.")
+	@DeleteMapping("/delete/{buildingId}")
+	public ResponseEntity<Map<String, String>> deleteByBuildingId(
+		@PathVariable Long buildingId,
+		HttpServletRequest httpRequest) {
+
+		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+		if (accessToken == null) {
+			throw new MissingTokenException();
+		}
+		if (!jwtTokenProvider.validateToken(accessToken)) {
+			throw new InvalidTokenException();
+		}
+
+		String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
+		recentSearchService.deleteSearchKeywordByBuildingId(memberId, buildingId);
+
+		Map<String, String> response = new HashMap<>();
+		response.put("message", "해당 건물의 검색어가 삭제되었습니다.");
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
@@ -1,5 +1,6 @@
 package com.YOGIITSU.repository;
 
+import com.YOGIITSU.entity.Building;
 import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.entity.RecentSearch;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,7 @@ public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long
 
 	// 검색어 삭제
 	void deleteByMemberAndKeyword(Member member, String keyword);
+	// 특정 회원과 건물에 대한 검색어 조회
+	List<RecentSearch> findByMemberAndBuildingId(Member member, Long buildingId);
+
 }

--- a/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
@@ -15,6 +15,10 @@ public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long
 
 	// 검색어 삭제
 	void deleteByMemberAndKeyword(Member member, String keyword);
+
+	// 특정 회원의 모든 검색어 삭제
+	void deleteByMember(Member member);
+
 	// 특정 회원과 건물에 대한 검색어 조회
 	List<RecentSearch> findByMemberAndBuildingId(Member member, Long buildingId);
 

--- a/src/main/java/com/YOGIITSU/service/RecentSearchService.java
+++ b/src/main/java/com/YOGIITSU/service/RecentSearchService.java
@@ -75,4 +75,11 @@ public class RecentSearchService {
 		recentSearchRepository.delete(searchList.get(0));
 	}
 
+	// 검색어 전체 삭제
+	@Transactional
+	public void deleteAllSearchKeywords(String memberId) {
+		Member member = memberRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+		recentSearchRepository.deleteByMember(member);
+	}
 }

--- a/src/main/java/com/YOGIITSU/service/RecentSearchService.java
+++ b/src/main/java/com/YOGIITSU/service/RecentSearchService.java
@@ -32,13 +32,6 @@ public class RecentSearchService {
 		// 기존에 같은 검색어가 있으면 삭제
 		recentSearchRepository.deleteByMemberAndKeyword(member, keyword);
 
-		// 최대 개수(6개) 초과 시 가장 오래된 검색어 삭제
-		List<RecentSearch> recentSearches = recentSearchRepository.findByMemberOrderBySearchedAtDesc(
-			member);
-		if (recentSearches.size() >= 6) {
-			recentSearchRepository.delete(recentSearches.getLast());
-		}
-
 		// alias 기반으로 building 매핑
 		Building matchedBuilding = buildingAliasRepository
 			.findFirstByAliasContainingOrderByIdAsc(keyword)
@@ -66,4 +59,20 @@ public class RecentSearchService {
 			.map(RecentSearchResponseDto::new)
 			.toList();
 	}
+
+	// 검색어 단건 삭제
+	@Transactional
+	public void deleteSearchKeywordByBuildingId(String memberId, Long buildingId) {
+		Member member = memberRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+		List<RecentSearch> searchList = recentSearchRepository.findByMemberAndBuildingId(member, buildingId);
+		if (searchList.isEmpty()) {
+			throw new EntityNotFoundException("해당 건물과 연결된 검색어가 없습니다.");
+		}
+
+		// 가장 최근 항목 하나만 삭제
+		recentSearchRepository.delete(searchList.get(0));
+	}
+
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/search` → `develop`

### 변경 사항
1. buildingId 기반 단건 삭제 API 추가 `DELETE /search/delete/{buildingId}`
    - 사용자와 buildingId 조합으로 저장된 특정 검색어를 단건 삭제
    - RecentSearchRepository.findByMemberAndBuildingId() 사용

2. 전체 최근 검색어 삭제 API 추가 `DELETE /search/deleteAll`
    - 해당 사용자의 모든 최근 검색어 삭제

### 테스트 결과

- 단건 삭제 -> buildingId 기준 검색어 1건 정확히 삭제 확인
- 전체 삭제 -> 전체 최근 검색어 일괄 삭제 후 목록 비어 있음 확인
- 잘못된 buildingId -> 존재하지 않거나 매핑 안 된 경우 예외 메시지 반환 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 최근 검색어에서 특정 건물에 대한 검색어를 개별 삭제할 수 있는 기능이 추가되었습니다.
  * 모든 최근 검색어를 한 번에 삭제할 수 있는 기능이 추가되었습니다.

* **기능 개선**
  * 최근 검색어가 6개로 제한되던 기존 제한이 제거되어, 더 많은 검색어를 저장할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->