### PR TITLE
fix: 검색어 중복 저장 에러 수정 및 삭제 쿼리 JPQL로 리팩토링

### DIFF
--- a/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
@@ -4,6 +4,9 @@ import com.YOGIITSU.entity.Building;
 import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.entity.RecentSearch;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 
@@ -14,7 +17,10 @@ public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long
 	List<RecentSearch> findByMemberOrderBySearchedAtDesc(Member member);
 
 	// 검색어 삭제
-	void deleteByMemberAndKeyword(Member member, String keyword);
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM RecentSearch rs WHERE rs.member = :member AND rs.keyword = :keyword")
+	void deleteByMemberAndKeyword(@Param("member") Member member, @Param("keyword") String keyword);
+
 
 	// 특정 회원의 모든 검색어 삭제
 	void deleteByMember(Member member);

--- a/src/main/java/com/YOGIITSU/service/RecentSearchService.java
+++ b/src/main/java/com/YOGIITSU/service/RecentSearchService.java
@@ -31,6 +31,7 @@ public class RecentSearchService {
 
 		// 기존에 같은 검색어가 있으면 삭제
 		recentSearchRepository.deleteByMemberAndKeyword(member, keyword);
+		recentSearchRepository.flush();
 
 		// alias 기반으로 building 매핑
 		Building matchedBuilding = buildingAliasRepository


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/search` → `develop`

### 변경 사항
- saveSearchKeyword 메서드에서 deleteByMemberAndKeyword() 호출 후 flush()를 명시적으로 수행하여, 삭제 쿼리가 즉시 반영되도록 처리 → 중복 저장 시 발생하던 Unique 제약 조건 위반 문제 해결

- RecentSearchRepository의 deleteByMemberAndKeyword 메서드를 Spring Data JPA의 메서드 네이밍 전략 방식에서 JPQL 기반의 커스텀 쿼리로 변경

- @Modifying(clearAutomatically = true) 추가로 영속성 컨텍스트 동기화 충돌 방지

- JPQL을 활용해 명시적인 제어 및 성능 개선


### 테스트 결과
- 동일한 검색어를 반복 저장해도 Duplicate entry 예외 발생하지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 최근 검색어 삭제 시 데이터베이스 동기화가 즉시 반영되도록 개선되었습니다.  
* **기타**
  * 최근 검색어 삭제 기능의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->