### PR TITLE
feat: 셔틀버스 시간표 조회 API 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/ShuttleController.java
+++ b/src/main/java/com/YOGIITSU/controller/ShuttleController.java
@@ -1,0 +1,30 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.dto.ResponseDto.ShuttleScheduleResponseDto;
+import com.YOGIITSU.service.ShuttleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "셔틀버스 API", description = "셔틀버스 운행 시간표 및 다음 운행 시간 정보를 제공합니다.")
+@RestController
+@RequestMapping("/shuttles")
+public class ShuttleController {
+
+	private final ShuttleService shuttleService;
+
+	public ShuttleController(ShuttleService shuttleService) {
+		this.shuttleService = shuttleService;
+	}
+
+	@Operation(
+		summary = "셔틀버스 시간표 및 다음 운행 시간 조회",
+		description = "현재 시간을 기준으로 가장 가까운 2개의 셔틀 시간과 전체 시간표, 셔틀 노선 경로를 반환합니다."
+	)
+	@GetMapping("/schedule")
+	public ShuttleScheduleResponseDto getShuttleSchedule() {
+		return shuttleService.getShuttleSchedule();
+	}
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/ShuttleScheduleResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/ShuttleScheduleResponseDto.java
@@ -1,0 +1,11 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import java.util.List;
+
+public record ShuttleScheduleResponseDto(
+	List<String> nextShuttleTime,
+	List<String> timeTable,
+	List<String> route
+) {
+
+}

--- a/src/main/java/com/YOGIITSU/service/ShuttleService.java
+++ b/src/main/java/com/YOGIITSU/service/ShuttleService.java
@@ -1,0 +1,63 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.dto.ResponseDto.ShuttleScheduleResponseDto;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ShuttleService {
+
+	private final List<LocalTime> timeTable = Arrays.asList(
+		LocalTime.of(9, 10), LocalTime.of(9, 20),
+		LocalTime.of(10, 10), LocalTime.of(10, 20),
+		LocalTime.of(11, 10), LocalTime.of(11, 20),
+		LocalTime.of(12, 10), LocalTime.of(12, 20),
+		LocalTime.of(13, 20), LocalTime.of(14, 20),
+		LocalTime.of(15, 20)
+	);
+
+	private final List<String> route = Arrays.asList(
+		"인문대 앞",
+		"학생회관 사거리",
+		"ICT 융합대학",
+		"음악대학",
+		"제1공학관",
+		"후문(제4공학관)",
+		"미술대학(조형관)"
+	);
+
+	public ShuttleScheduleResponseDto getShuttleSchedule() {
+		List<String> nextShuttleTime = getNextTwoShuttles();
+		List<String> timeTableString = timeTable.stream()
+			.map(LocalTime::toString)
+			.collect(Collectors.toList());
+
+		return new ShuttleScheduleResponseDto(nextShuttleTime, timeTableString, route);
+	}
+
+	private List<String> getNextTwoShuttles() {
+		LocalTime now = LocalTime.now(ZoneId.of("Asia/Seoul"));
+
+		List<LocalTime> upcoming = timeTable.stream()
+			.filter(t -> !t.isBefore(now))
+			.collect(Collectors.toList());
+
+		List<LocalTime> result = new ArrayList<>();
+		result.addAll(upcoming);
+
+		int remaining = 2 - result.size();
+		if (remaining > 0) {
+			result.addAll(timeTable.subList(0, remaining));
+		}
+
+		return result.subList(0, 2).stream()
+			.map(LocalTime::toString)
+			.collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`feature/shuttle-schedule-api` → `develop`

### 변경 사항

- `/shuttles/schedule` GET API 엔드포인트 추가
- 현재 시간을 기준으로 가장 가까운 2개의 셔틀 시간을 계산하여 반환
- 전체 시간표(`timeTable`) 및 셔틀 경로(`route`) 포함된 DTO 설계

### 테스트 결과

- 현재 시간 기준 최신 시간 순서로 `nextShuttleTime` 2개 잘 반환됨
- `timeTable` 및 `route`도 정상 출력 확인