### PR TITLE
feat: FacilityMarker 응답에 type 필드 추가 및 서비스 로직 반영

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/FacilityMarkerController.java
+++ b/src/main/java/com/YOGIITSU/controller/FacilityMarkerController.java
@@ -31,7 +31,7 @@ public class FacilityMarkerController {
 	@GetMapping
 	public List<FacilityMarkerResponseDto> getMarkersByType(
 		@Parameter(
-			description = "시설 유형 (RESTAURANT: 식당, PARKING: 주차장, CONVENIENCE_CAFE: 카페 및 편의점, SHUTTLE_BUS: 셔틀버스 정류장)",
+			description = "시설 유형 (RESTAURANT: 식당, PARKING: 주차장, CONVENIENCE_CAFE: 카페 및 편의점, SHUTTLE_BUS: 셔틀버스 정류장, PRINTER: 프린터기)",
 			example = "PARKING",
 			required = true
 		)

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/FacilityMarkerResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/FacilityMarkerResponseDto.java
@@ -11,4 +11,5 @@ public class FacilityMarkerResponseDto {
 	private Double latitude;
 	private Double longitude;
 	private Long buildingId;
+	private String type;
 }

--- a/src/main/java/com/YOGIITSU/enums/FacilityType.java
+++ b/src/main/java/com/YOGIITSU/enums/FacilityType.java
@@ -4,5 +4,6 @@ public enum FacilityType {
 	RESTAURANT,
 	PARKING,
 	CONVENIENCE_CAFE,
-	SHUTTLE_BUS
+	SHUTTLE_BUS,
+	PRINTER
 }

--- a/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
+++ b/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
@@ -34,8 +34,8 @@ public class FacilityMarkerService {
 				f.getLatitude(),
 				f.getLongitude(),
 				f.getBuilding() != null ? f.getBuilding().getId() : null, // 빌딩 ID 추가
-				f.getType().name(
-				)))
+				f.getType().name()
+			))
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
+++ b/src/main/java/com/YOGIITSU/service/FacilityMarkerService.java
@@ -33,8 +33,9 @@ public class FacilityMarkerService {
 				f.getPlaceName(),
 				f.getLatitude(),
 				f.getLongitude(),
-				f.getBuilding() != null ? f.getBuilding().getId() : null // 빌딩 ID 추가
-			))
+				f.getBuilding() != null ? f.getBuilding().getId() : null, // 빌딩 ID 추가
+				f.getType().name(
+				)))
 			.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/facility-marker` → `develop`

### 변경 사항
- FacilityMarkerResponseDto에 type 필드(String) 추가

- 서비스 로직(FacilityMarkerService.getMarkersByType)에서 시설 유형 정보를 응답에 포함하도록 수정

- 프론트에서 마커 종류에 따라 아이콘 분기 처리가 가능해짐 (예: PRINTER, PARKING 등)


### 테스트 결과
- Swagger에서 각 시설 유형 요청 시 type 필드가 포함된 응답 정상 확인
```
  {
    "name": "인문대 앞",
    "latitude": 37.212929,
    "longitude": 126.978009,
    "buildingId": null,
    "type": "SHUTTLE_BUS"
  }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 시설 마커 응답에 시설 유형 정보가 추가되었습니다.
  * 프린터(프린터기) 시설 유형이 새롭게 지원됩니다.

* **문서**
  * API 문서에 프린터 시설 유형이 안내되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->