### PR TITLE
feat: 층 정보(B3F~지상) 정렬 로직 개선

### DIFF
--- a/src/main/java/com/YOGIITSU/converter/BuildingConverter.java
+++ b/src/main/java/com/YOGIITSU/converter/BuildingConverter.java
@@ -47,9 +47,14 @@ public class BuildingConverter {
 			.latitude(building.getLatitude())
 			.longitude(building.getLongitude())
 			.facilities(building.getBuildingFacilities().stream()
-				.sorted(Comparator.comparing(BuildingFacility::getFloor,
-						Comparator.nullsLast(String::compareTo))
-					.thenComparing(BuildingFacility::getName))
+				.sorted(Comparator
+					.comparing(
+						BuildingFacility::getFloor,
+						Comparator.nullsLast(
+							Comparator.comparingInt(this::convertFloorStringToOrder))
+					)
+					.thenComparing(BuildingFacility::getName)
+				)
 				.map(facility -> FacilityResponseDto.builder()
 					.name(facility.getName())
 					.floor(facility.getFloor())
@@ -89,11 +94,32 @@ public class BuildingConverter {
 	private List<FloorImageResponseDto> convertToFloorPlanResponseDtos(
 		List<BuildingFloorImage> floorImages) {
 		return floorImages.stream()
-			.sorted(Comparator.comparing(BuildingFloorImage::getFloor))
+			.sorted(Comparator.comparing(
+				BuildingFloorImage::getFloor,
+				Comparator.nullsLast(Comparator.comparingInt(this::convertFloorStringToOrder))
+			))
 			.map(floorImage -> FloorImageResponseDto.builder()
 				.floor(floorImage.getFloor())
 				.imageUrl(floorImage.getImageUrl())
 				.build())
 			.collect(Collectors.toList());
+	}
+
+	/**
+	 * "B3F", "1F", "2F" 등의 문자열을 정렬 가능한 숫자로 변환 B3F -> -3, B2F -> -2, B1F -> -1, 1F -> 1, 2F -> 2 등
+	 */
+	private int convertFloorStringToOrder(String floor) {
+		if (floor == null) {
+			return Integer.MAX_VALUE; // null은 가장 마지막
+		}
+		try {
+			if (floor.startsWith("B")) {
+				return -Integer.parseInt(floor.substring(1, floor.length() - 1));
+			} else if (floor.endsWith("F")) {
+				return Integer.parseInt(floor.substring(0, floor.length() - 1));
+			}
+		} catch (NumberFormatException ignored) {
+		}
+		return Integer.MAX_VALUE; // 예외나 비정상 문자열도 마지막에 정렬
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/building` → `develop`

### 변경 사항
- 건물 상세 응답에서 층 정렬 기준 개선

- floorPlans(층별 이미지), facilities(편의시설 목록)에 대해 `"B3F → B2F → B1F → 1F → 2F → …"` 순으로 정렬되도록 커스텀 Comparator 적용

- convertFloorStringToOrder() 메서드 추가: B3F → -3, 1F → 1 등으로 정수화하여 정렬

- null 또는 예외는 Integer.MAX_VALUE 처리로 마지막에 표시
### 테스트 결과
- Swagger를 통해 미래혁신관 조회 시 "B3F → B2F → B1F → 1F → …" 순서로 층 이미지와 시설 정렬됨을 확인

- NULL 층 정보(예: 엘리베이터, 정수기)는 마지막에 정렬됨 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 건물 시설 및 층 이미지가 실제 층 순서(예: B3F, 1F, 2F 등)에 맞게 자연스럽게 정렬되도록 개선되었습니다. 이제 지하와 지상 층이 올바른 순서로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->