### PR TITLE
YogiitsuApplication에 @EnableConfigurationProperties 등록

### DIFF
--- a/src/main/java/com/YOGIITSU/YogiitsuApplication.java
+++ b/src/main/java/com/YOGIITSU/YogiitsuApplication.java
@@ -1,14 +1,17 @@
 package com.YOGIITSU;
 
+import com.YOGIITSU.config.handler.EmailProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableConfigurationProperties(EmailProperties.class)
 public class YogiitsuApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(YogiitsuApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(YogiitsuApplication.class, args);
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/` → `develop`

### 변경 사항
- YogiitsuApplication 클래스에 @EnableConfigurationProperties(EmailProperties.class) 애너테이션 추가
- application.yml의 email.allowed-domains 설정이 EmailProperties에 정상 바인딩되도록 설정

### 테스트 결과
- 허용된 도메인(suwon.ac.kr, naver.com, gmail.com)으로 요청 시 이메일 인증 정상 동작