### PR TITLE
FIND_ID, FIND_PASSWORD 목적에 대해 로그인 예외 제거

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -8,7 +8,6 @@ import com.YOGIITSU.dto.RequestDto.FindMemberIdRequestDto;
 import com.YOGIITSU.dto.RequestDto.PasswordCheckRequestDto;
 import com.YOGIITSU.dto.RequestDto.PasswordResetRequestDto;
 import com.YOGIITSU.dto.ResponseDto.FindMemberIdResponseDto;
-import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import com.YOGIITSU.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,129 +29,129 @@ import java.util.Map;
 @RequestMapping("/members")
 public class MemberController {
 
-	private final MemberService memberService;
-	private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-	private static final String NO_EMAIL_FOUND = "가입 이력이 없는 이메일입니다.";
-	private static final String EMAIL_MATCH_FOUND = "이메일 정보와 일치하는 아이디가 있습니다.";
-	private static final String MEMBER_DELETION_SUCCESS = "님의 회원 탈퇴가 완료되었습니다.";
+    private static final String NO_EMAIL_FOUND = "가입 이력이 없는 이메일입니다.";
+    private static final String EMAIL_MATCH_FOUND = "이메일 정보와 일치하는 아이디가 있습니다.";
+    private static final String MEMBER_DELETION_SUCCESS = "님의 회원 탈퇴가 완료되었습니다.";
 
-	/**
-	 * 로그인 API
-	 *
-	 * @param memberLoginRequestDto 요청 데이터 (아이디, 비밀번호)
-	 * @return TokenInfo JWT 토큰 정보
-	 */
-	@Operation(summary = "로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
-	@PostMapping("/login")
-	public ResponseEntity<Map<String, Object>> login(
-		@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
-		return memberService.login(
-			memberLoginRequestDto.getMemberId(),
-			memberLoginRequestDto.getPassword()
-		);
-	}
+    /**
+     * 로그인 API
+     *
+     * @param memberLoginRequestDto 요청 데이터 (아이디, 비밀번호)
+     * @return TokenInfo JWT 토큰 정보
+     */
+    @Operation(summary = "로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, Object>> login(
+        @RequestBody MemberLoginRequestDto memberLoginRequestDto) {
+        return memberService.login(
+            memberLoginRequestDto.getMemberId(),
+            memberLoginRequestDto.getPassword()
+        );
+    }
 
 
-	/**
-	 * 아이디 찾기 API
-	 *
-	 * @param request 요청 데이터 (이메일)
-	 * @return 아이디 찾기 결과
-	 */
-	@Operation(summary = "아이디 찾기", description = "이메일을 기반으로 등록된 아이디를 조회합니다.")
-	@PostMapping("/find-id")
-	public ResponseEntity<FindMemberIdResponseDto> findId(
-		@RequestBody FindMemberIdRequestDto request) {
-		String email = request.getEmail();
-		String memberId = memberService.findIdByEmail(email);
+    /**
+     * 아이디 찾기 API
+     *
+     * @param request 요청 데이터 (이메일)
+     * @return 아이디 찾기 결과
+     */
+    @Operation(summary = "아이디 찾기", description = "이메일을 기반으로 등록된 아이디를 조회합니다.")
+    @PostMapping("/find-id")
+    public ResponseEntity<FindMemberIdResponseDto> findId(
+        @RequestBody FindMemberIdRequestDto request) {
+        String email = request.getEmail();
+        String memberId = memberService.findIdByEmail(email);
 
-		FindMemberIdResponseDto response = FindMemberIdResponseDto.builder()
-			.status(memberId != null ? "success" : "error")
-			.id(memberId)
-			.message(memberId == null ? NO_EMAIL_FOUND : EMAIL_MATCH_FOUND)
-			.build();
+        FindMemberIdResponseDto response = FindMemberIdResponseDto.builder()
+            .status(memberId != null ? "success" : "error")
+            .id(memberId)
+            .message(memberId == null ? NO_EMAIL_FOUND : EMAIL_MATCH_FOUND)
+            .build();
 
-		return ResponseEntity.ok(response);
-	}
+        return ResponseEntity.ok(response);
+    }
 
-	/**
-	 * 회원 탈퇴 API
-	 *
-	 * @param request HTTP 요청 객체
-	 */
-	@Operation(summary = "회원 탈퇴", description = "비밀번호 확인 후 JWT 토큰 기반으로 회원 탈퇴 처리합니다.")
-	@DeleteMapping("/delete")
-	public ResponseEntity<Map<String, String>> deleteMember(
-		@RequestBody PasswordCheckRequestDto request, HttpServletRequest httpRequest) {
-		// 1. 요청에서 JWT 토큰 추출
-		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+    /**
+     * 회원 탈퇴 API
+     *
+     * @param request HTTP 요청 객체
+     */
+    @Operation(summary = "회원 탈퇴", description = "비밀번호 확인 후 JWT 토큰 기반으로 회원 탈퇴 처리합니다.")
+    @DeleteMapping("/delete")
+    public ResponseEntity<Map<String, String>> deleteMember(
+        @RequestBody PasswordCheckRequestDto request, HttpServletRequest httpRequest) {
+        // 1. 요청에서 JWT 토큰 추출
+        String accessToken = jwtTokenProvider.resolveToken(httpRequest);
 
-		// 2. 토큰이 없으면 예외 발생
-		if (accessToken == null) {
-			throw new MissingTokenException();
-		}
+        // 2. 토큰이 없으면 예외 발생
+        if (accessToken == null) {
+            throw new MissingTokenException();
+        }
 
-		// 3. 토큰이 유효한지 확인, 유효하지 않으면 예외 발생
-		if (!jwtTokenProvider.validateToken(accessToken)) {
-			throw new InvalidTokenException();
-		}
+        // 3. 토큰이 유효한지 확인, 유효하지 않으면 예외 발생
+        if (!jwtTokenProvider.validateToken(accessToken)) {
+            throw new InvalidTokenException();
+        }
 
-		// 4. 유효한 토큰이라면 사용자 ID 추출
-		String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
+        // 4. 유효한 토큰이라면 사용자 ID 추출
+        String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
 
-		// 5. 회원 탈퇴 처리
-		memberService.deleteMember(memberId, request.getPassword());
+        // 5. 회원 탈퇴 처리
+        memberService.deleteMember(memberId, request.getPassword());
 
-		// 6. 탈퇴 성공 메시지 반환
-		Map<String, String> response = new HashMap<>();
-		response.put("message", memberId + MEMBER_DELETION_SUCCESS);
-		return ResponseEntity.ok(response);
-	}
+        // 6. 탈퇴 성공 메시지 반환
+        Map<String, String> response = new HashMap<>();
+        response.put("message", memberId + MEMBER_DELETION_SUCCESS);
+        return ResponseEntity.ok(response);
+    }
 
-	/**
-	 * 비밀번호 변경 API
-	 *
-	 * @param requestDto  새로운 비밀번호와 확인 비밀번호
-	 * @param httpRequest HTTP 요청 객체
-	 * @return 비밀번호 변경 결과
-	 */
-	@Operation(summary = "비밀번호 변경", description = "로그인된 상태에서 새 비밀번호로 변경합니다.")
-	@PatchMapping("/change-password")
-	public ResponseEntity<Map<String, String>> changePassword(
-		@RequestBody ChangePasswordRequestDto requestDto, HttpServletRequest httpRequest) {
+    /**
+     * 비밀번호 변경 API
+     *
+     * @param requestDto  새로운 비밀번호와 확인 비밀번호
+     * @param httpRequest HTTP 요청 객체
+     * @return 비밀번호 변경 결과
+     */
+    @Operation(summary = "비밀번호 변경", description = "로그인된 상태에서 새 비밀번호로 변경합니다.")
+    @PatchMapping("/change-password")
+    public ResponseEntity<Map<String, String>> changePassword(
+        @RequestBody ChangePasswordRequestDto requestDto, HttpServletRequest httpRequest) {
 
-		// 1. JWT 토큰 추출 및 유효성 검사
-		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
-		if (accessToken == null || !jwtTokenProvider.validateToken(accessToken)) {
-			throw new InvalidTokenException();
-		}
+        // 1. JWT 토큰 추출 및 유효성 검사
+        String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+        if (accessToken == null || !jwtTokenProvider.validateToken(accessToken)) {
+            throw new InvalidTokenException();
+        }
 
-		// 2. 현재 인증된 사용자 가져오기
-		Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-		String memberId = authentication.getName();
+        // 2. 현재 인증된 사용자 가져오기
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        String memberId = authentication.getName();
 
-		// 3. 비밀번호 변경 처리
-		memberService.changePassword(memberId, requestDto.getNewPassword(),
-			requestDto.getConfirmPassword());
+        // 3. 비밀번호 변경 처리
+        memberService.changePassword(memberId, requestDto.getNewPassword(),
+            requestDto.getConfirmPassword());
 
-		// 4. 성공 메시지 반환
-		return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
-	}
+        // 4. 성공 메시지 반환
+        return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
+    }
 
-	/**
-	 * 비밀번호 찾기 (재설정) 로그인되지 않은 상태 -> 이메일 인증 완료 여부를 기반으로 비밀번호 재설정 허용
-	 *
-	 * @param requestDto 요청 데이터 (이메일, 새 비밀번호, 확인 비밀번호)
-	 * @return 비밀번호 재설정 결과
-	 */
-	@Operation(summary = "비밀번호 찾기 (재설정)", description = "비밀번호를 찾기 위해 이메일 인증을 완료한 사용자가 비밀번호를 재설정합니다.")
-	@PostMapping("/find-password")
-	public ResponseEntity<Map<String, String>> resetPassword(
-		@RequestBody PasswordResetRequestDto requestDto) {
+    /**
+     * 비밀번호 찾기 (재설정) 로그인되지 않은 상태 -> 이메일 인증 완료 여부를 기반으로 비밀번호 재설정 허용
+     *
+     * @param requestDto 요청 데이터 (이메일, 새 비밀번호, 확인 비밀번호)
+     * @return 비밀번호 재설정 결과
+     */
+    @Operation(summary = "비밀번호 찾기 (재설정)", description = "비밀번호를 찾기 위해 이메일 인증을 완료한 사용자가 비밀번호를 재설정합니다.")
+    @PostMapping("/find-password")
+    public ResponseEntity<Map<String, String>> resetPassword(
+        @RequestBody PasswordResetRequestDto requestDto) {
 
-		memberService.resetPasswordAfterEmailVerification(requestDto);
+        memberService.resetPasswordAfterEmailVerification(requestDto);
 
-		return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
-	}
+        return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
+    }
 }

--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -16,6 +16,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -72,7 +73,8 @@ public class MemberController {
             .message(memberId == null ? NO_EMAIL_FOUND : EMAIL_MATCH_FOUND)
             .build();
 
-        return ResponseEntity.ok(response);
+        return memberId == null ? ResponseEntity.status(HttpStatus.NOT_FOUND).body(response)
+            : ResponseEntity.ok(response);
     }
 
     /**

--- a/src/main/java/com/YOGIITSU/entity/EmailPurpose.java
+++ b/src/main/java/com/YOGIITSU/entity/EmailPurpose.java
@@ -6,20 +6,22 @@ import lombok.Getter;
 @Getter
 public enum EmailPurpose {
     // DB에 없어야 함 (false)
-    SIGNUP(false, "이메일 인증이 완료되었습니다. 회원가입을 계속 진행해주세요."),
-    EMAIL_CHANGE_NEW(false, "이메일이 변경되었습니다. 보안을 위해 다시 로그인해주세요."),
+    SIGNUP(false, false, "이메일 인증이 완료되었습니다. 회원가입을 계속 진행해주세요."),
+    EMAIL_CHANGE_NEW(false, true, "이메일이 변경되었습니다. 보안을 위해 다시 로그인해주세요."),
+    FIND_ID(true, false, "이메일 인증이 완료되었습니다. 아이디 찾기를 계속 진행해주세요."),
+    FIND_PASSWORD(true, false, "이메일 인증이 완료되었습니다. 비밀번호 재설정을 계속 진행해주세요."),
 
     // DB에 반드시 있어야 함 (true)
-    EMAIL_CHANGE_OLD(true, "이메일 인증이 완료되었습니다."),
-    PASSWORD_CHANGE(true, "이메일 인증이 완료되었습니다. 비밀번호 재설정을 계속 진행해주세요."),
-    FIND_ID(true, "이메일 인증이 완료되었습니다. 아이디 찾기를 계속 진행해주세요."),
-    FIND_PASSWORD(true, "이메일 인증이 완료되었습니다. 비밀번호 재설정을 계속 진행해주세요.");
+    EMAIL_CHANGE_OLD(true, true, "이메일 인증이 완료되었습니다."),
+    PASSWORD_CHANGE(true, true, "이메일 인증이 완료되었습니다. 비밀번호 재설정을 계속 진행해주세요.");
 
     private final boolean mustExist;
+    private final boolean requiresAuth;
     private final String successMessage;
 
-    EmailPurpose(boolean mustExist, String successMessage) {
+    EmailPurpose(boolean mustExist, boolean requiresAuth, String successMessage) {
         this.mustExist = mustExist;
+        this.requiresAuth = requiresAuth;
         this.successMessage = successMessage;
     }
 }

--- a/src/main/java/com/YOGIITSU/service/EmailService.java
+++ b/src/main/java/com/YOGIITSU/service/EmailService.java
@@ -114,8 +114,8 @@ public class EmailService {
         }
 
         // 인증이 필요한 목적인지 확인
-        if (requiresAuthentication(purpose)) {
-            checkAuthentication(auth); //목적이 signup인 경우에는 로그인 요청을 강요하면 안됨
+        if (purpose.isRequiresAuth()) {
+            checkAuthentication(auth);
         }
 
         if (purpose.isMustExist()) {
@@ -226,9 +226,5 @@ public class EmailService {
         if (!memberRepository.existsByEmail(email)) {
             throw new IllegalArgumentException("해당 이메일로 가입된 계정이 존재하지 않습니다.");
         }
-    }
-
-    private boolean requiresAuthentication(EmailPurpose purpose) {
-        return purpose != EmailPurpose.SIGNUP;
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/email-change` → `develop`

### 변경 사항
- EmailPurpose enum에 requiresAuth 필드를 도입하여 인증이 필요한 목적을 명시적으로 분리
- EmailService.validateEmailRequest() 내부에서 requiresAuth 값이 true일 때만 로그인 인증을 요구하도록 수정
- 로그인 없이 사용 가능한 아이디 찾기(FIND_ID), 비밀번호 찾기(FIND_PASSWORD)에서도 더 이상 "로그인이 필요한 요청입니다" 예외가 발생하지 않도록 수정

### 테스트 결과
- 아이디 찾기, 비밀번호 찾기에서 로그인 없이도 인증 요청 및 처리 가능함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 이메일 인증 목적에 따라 인증 필요 여부를 세분화할 수 있는 기능이 추가되었습니다.
  * 새로운 이메일 목적(FIND_ID, FIND_PASSWORD)이 추가되었습니다.

* **리팩터링**
  * 이메일 인증 관련 내부 로직이 단순화되어 관리가 용이해졌습니다.
  * 회원 ID 찾기 시 해당 이메일이 없으면 404 Not Found 상태를 반환하도록 변경되었습니다.

* **스타일**
  * 불필요한 import 문이 제거되고 코드 포맷이 일부 정돈되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->