### PR TITLE
fix: SignUpService에 아이디는 영문으로 시작하도록 정규식 및 예외 메시지 수정

### DIFF
--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -47,7 +47,7 @@ public class SignUpService {
         // 3-1. 아이디 유효성 검사
         String memberIdPattern = "^[a-zA-Z][a-zA-Z0-9]{3,19}$";
         if (!Pattern.matches(memberIdPattern, dto.getMemberId())) {
-            throw new IllegalArgumentException("아이디는 4~20자의 영문 또는 영문+숫자로만 구성되어야 합니다.");
+            throw new IllegalArgumentException("아이디는 영문으로 시작하며, 4~20자의 영문과 숫자로만 구성되어야 합니다.");
         }
 
         // 4. 이메일 도메인 검사

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -45,10 +45,7 @@ public class SignUpService {
         }
 
         // 3-1. 아이디 유효성 검사
-        String memberIdPattern = "^[a-zA-Z][a-zA-Z0-9]{3,19}$";
-        if (!Pattern.matches(memberIdPattern, dto.getMemberId())) {
-            throw new IllegalArgumentException("아이디는 영문으로 시작하며, 4~20자의 영문과 숫자로만 구성되어야 합니다.");
-        }
+        validateMemberId(dto.getMemberId());
 
         // 4. 이메일 도메인 검사
         boolean isValidDomain = ALLOWED_DOMAINS.stream()
@@ -101,6 +98,18 @@ public class SignUpService {
         }
         if (!Pattern.compile("[!@#$%^&*(),.?\":{}|<>]").matcher(password).find()) {
             throw new IllegalArgumentException("비밀번호에는 특수문자가 최소 1자 이상 포함되어야 합니다.");
+        }
+    }
+
+    private void validateMemberId(String memberId) {
+        if (memberId.length() < 4 || memberId.length() > 20) {
+            throw new IllegalArgumentException("아이디는 4자 이상 20자 이하이어야 합니다.");
+        }
+        if (!Pattern.compile("^[a-zA-Z]").matcher(memberId).find()) {
+            throw new IllegalArgumentException("아이디는 반드시 영문자로 시작해야 합니다.");
+        }
+        if (!Pattern.compile("^[a-zA-Z0-9]+$").matcher(memberId).matches()) {
+            throw new IllegalArgumentException("아이디는 영문자와 숫자로만 구성되어야 합니다.");
         }
     }
 }

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -45,7 +45,7 @@ public class SignUpService {
         }
 
         // 3-1. 아이디 유효성 검사
-        String memberIdPattern = "^(?=.*[a-zA-Z])[a-zA-Z0-9]{4,20}$";
+        String memberIdPattern = "^[a-zA-Z][a-zA-Z0-9]{3,19}$";
         if (!Pattern.matches(memberIdPattern, dto.getMemberId())) {
             throw new IllegalArgumentException("아이디는 4~20자의 영문 또는 영문+숫자로만 구성되어야 합니다.");
         }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/signup` → `develop`

### 변경 사항
- 회원가입 서비스(SignUpService)
  - 아이디 유효성 검사 정규식 수정:
     - 기존: 영문자 포함 여부만 검사 (^(?=.*[a-zA-Z])[a-zA-Z0-9]{4,20}$)
     - 변경: 반드시 영문자로 시작하도록 수정 (^[a-zA-Z][a-zA-Z0-9]{3,19}$)

### 테스트 결과
- 유효한 아이디(user1, Abc123, a1b2)는 정상 가입 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 회원 가입 시 아이디가 반드시 영문자로 시작하도록 입력 규칙이 강화되었습니다. (아이디는 영문자로 시작하고, 총 4~20자의 영문자 또는 숫자만 허용)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->