### PR TITLE
fix: 회원가입 시 이름 중복 SignUpService에예외 메시지를 명확하게 수정하여 사용자 이해도 향상

### DIFF
--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -58,7 +58,7 @@ public class SignUpService {
 
         // 5. 이름 중복 체크
         if (memberRepository.findByUserName(dto.getUserName()).isPresent()) {
-            throw new IllegalArgumentException("해당 이름으로 가입한 내역이 있습니다.");
+            throw new IllegalArgumentException("이미 사용 중인 이름입니다. 다른 이름을 입력해주세요.");
         }
 
         // 6. 이름 유효성 검사 (영문/한글/숫자, 특수문자 불가, 2~8자리)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/signup` → `develop`

### 변경 사항
- 회원가입 시 이름(username) 중복 체크 로직에서 예외 메시지를 사용자 친화적으로 수정
  - 변경: "이미 사용 중인 이름입니다. 다른 이름을 입력해주세요."

### 테스트 결과
- 중복된 이름으로 요청 시 변경된 메시지가 정상적으로 반환됨을 확인