### PR TITLE
Feature/signup

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
+++ b/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
@@ -42,7 +42,7 @@ public class EmailVerificationController {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(EmailVerificationResponseDto.builder()
                         .status("error")
-                        .message("인증 실패: 인증 코드가 일치하지 않습니다.")
+                        .message("인증 코드가 일치하지 않습니다.")
                         .email(null)
                         .build());
             }
@@ -62,7 +62,7 @@ public class EmailVerificationController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(EmailVerificationResponseDto.builder()
                     .status("error")
-                    .message("인증 실패: " + e.getMessage())
+                    .message(e.getMessage())
                     .email(null)
                     .build());
         }

--- a/src/main/java/com/YOGIITSU/service/EmailService.java
+++ b/src/main/java/com/YOGIITSU/service/EmailService.java
@@ -204,7 +204,7 @@ public class EmailService {
     public EmailMessage verifyEmailCode(String email, String code) {
         EmailMessage message = findEmailMessage(email, code);
         if (message.getExpiresAt().isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException("인증 코드가 유효하지 않습니다.");
+            throw new IllegalArgumentException("인증 코드가 만료되었습니다.");
         }
         return message;
     }
@@ -212,7 +212,7 @@ public class EmailService {
     // 이메일과 코드로 EmailMessage 조회
     private EmailMessage findEmailMessage(String email, String code) {
         return emailMessageRepository.findByEmailAndCode(email, code)
-            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 요청입니다."));
+            .orElseThrow(() -> new IllegalArgumentException("인증 코드가 만료되었습니다. 인증 코드를 재전송해 주세요."));
     }
 
     // 인증 승인 처리 및 저장


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

### 반영 브랜치  
`feature/signup` → `develop`

---

### 변경 사항
- `EmailService`에서 인증 코드 만료 시 사용자에게 더 명확한 안내 메시지를 제공하도록 예외 메시지 수정  
  - 변경 전: `"유효하지 않은 인증 요청입니다."`  
  - 변경 후: `"인증 코드가 만료되었습니다. 인증 코드를 재전송해 주세요."`
- `EmailVerificationController`에서 인증 실패 시 반환되던 `"인증 실패: "` 접두사를 제거하여, 응답 메시지를 깔끔하게 개선

---

### 테스트 결과
- 인증 코드가 일치하지 않거나 만료된 경우 다음과 같은 메시지가 정확히 반환되는 것 확인 (Swagger 및 실제 요청 테스트 완료)  
  - `"인증 코드가 만료되었습니다. 인증 코드를 재전송해 주세요."`  
  - `"인증 코드가 일치하지 않습니다."`
- 모든 메시지에서 `"인증 실패:"` 접두사가 제거되어 사용자가 혼란 없이 응답을 받을 수 있음
