### PR TITLE
feat: 지름길 API 구현

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/ShortcutController.java
+++ b/src/main/java/com/YOGIITSU/controller/ShortcutController.java
@@ -1,0 +1,50 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.dto.ResponseDto.ShortcutDetailResponseDto;
+import com.YOGIITSU.dto.ResponseDto.ShortcutListResponseDto;
+import com.YOGIITSU.service.ShortcutService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "지름길 API", description = "지름길 리스트 및 상세 정보 조회 API 제공")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/shortcuts")
+@Validated
+public class ShortcutController {
+
+    private final ShortcutService shortcutService;
+
+    /**
+     * 지름길 전체 목록 조회 API
+     */
+    @Operation(summary = "지름길 전체 목록 조회")
+    @GetMapping
+    public ResponseEntity<List<ShortcutListResponseDto>> getAllShortcuts() {
+        List<ShortcutListResponseDto> shortcuts = shortcutService.getAllShortcuts();
+        return ResponseEntity.ok(shortcuts);
+    }
+
+    /**
+     * 특정 지름길 상세 정보 조회 API
+     */
+    @Operation(summary = "지름길 상세 정보 조회")
+    @GetMapping("/{shortcutId}")
+    public ResponseEntity<ShortcutDetailResponseDto> getShortcutDetail(
+        @Parameter(description = "지름길 ID", example = "1")
+        @PathVariable Long shortcutId) {
+        ShortcutDetailResponseDto detail = shortcutService.getShortcutDetail(shortcutId);
+        return ResponseEntity.ok(detail);
+    }
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/CoordinateDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/CoordinateDto.java
@@ -1,0 +1,19 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import com.YOGIITSU.enums.TurnType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CoordinateDto {
+
+    private Double latitude;
+    private Double longitude;
+    private Integer pointOrder;
+    private String description;
+    private TurnType turnType;
+    private Double segmentDistance;
+    private String imageUrl;
+
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/ShortcutDetailResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/ShortcutDetailResponseDto.java
@@ -1,0 +1,18 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShortcutDetailResponseDto {
+
+    private Long shortcutId;
+    private String pointA;
+    private String pointB;
+    private Double distance;
+    private Integer duration;
+    private List<CoordinateDto> coordinates;
+
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/ShortcutListResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/ShortcutListResponseDto.java
@@ -1,0 +1,16 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShortcutListResponseDto {
+
+    private Long shortcutId;
+    private String pointA;
+    private String pointB;
+    private Double distance;
+    private Integer duration;
+
+}

--- a/src/main/java/com/YOGIITSU/entity/Shortcut.java
+++ b/src/main/java/com/YOGIITSU/entity/Shortcut.java
@@ -1,0 +1,46 @@
+package com.YOGIITSU.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "shortcut")
+public class Shortcut {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shortcut_id", updatable = false, nullable = false)
+    private Long shortcutId;
+
+    @Column(name = "point_a", nullable = false)
+    private String pointA;
+
+    @Column(name = "point_b", nullable = false)
+    private String pointB;
+
+    @Column(name = "distance", nullable = false)
+    private Double distance;
+
+    @Column(name = "duration", nullable = false)
+    private Integer duration;
+
+    @OneToMany(mappedBy = "shortcut", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ShortcutCoordinate> coordinates = new ArrayList<>();
+}

--- a/src/main/java/com/YOGIITSU/entity/Shortcut.java
+++ b/src/main/java/com/YOGIITSU/entity/Shortcut.java
@@ -3,6 +3,7 @@ package com.YOGIITSU.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -41,6 +42,6 @@ public class Shortcut {
     @Column(name = "duration", nullable = false)
     private Integer duration;
 
-    @OneToMany(mappedBy = "shortcut", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "shortcut", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<ShortcutCoordinate> coordinates = new ArrayList<>();
 }

--- a/src/main/java/com/YOGIITSU/entity/ShortcutCoordinate.java
+++ b/src/main/java/com/YOGIITSU/entity/ShortcutCoordinate.java
@@ -1,0 +1,58 @@
+package com.YOGIITSU.entity;
+
+import com.YOGIITSU.enums.TurnType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "shortcut_coordinate")
+public class ShortcutCoordinate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coordinate_id", updatable = false, nullable = false)
+    private Long coordinateId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shortcut_id", nullable = false)
+    private Shortcut shortcut;
+
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    @Column(name = "point_order", nullable = false)
+    private Integer pointOrder;
+
+    @Column(name = "segment_distance")
+    private Double segmentDistance; // 다음 좌표까지 거리 (단위: m)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "turn_type", nullable = false)
+    private TurnType turnType;    // 좌회전, 우회전, 직진 등
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+}

--- a/src/main/java/com/YOGIITSU/enums/TurnType.java
+++ b/src/main/java/com/YOGIITSU/enums/TurnType.java
@@ -1,0 +1,25 @@
+package com.YOGIITSU.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
+public enum TurnType {
+
+    STRAIGHT(11, "직진"),
+    LEFT_TURN(12, "좌회전"),
+    RIGHT_TURN(13, "우회전");
+
+    private final int code;
+    private final String description;
+
+    TurnType(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @JsonValue
+    public int getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/YOGIITSU/repository/ShortcutCoordinateRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/ShortcutCoordinateRepository.java
@@ -1,0 +1,19 @@
+package com.YOGIITSU.repository;
+
+import com.YOGIITSU.entity.ShortcutCoordinate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ShortcutCoordinateRepository extends JpaRepository<ShortcutCoordinate, Long> {
+
+    /**
+     * 특정 지름길 ID에 해당하는 지점들을 pointOrder 순으로 정렬해서 조회
+     */
+    @Query("SELECT sc FROM ShortcutCoordinate sc WHERE sc.shortcut.shortcutId = :shortcutId ORDER BY sc.pointOrder ASC")
+    List<ShortcutCoordinate> findCoordinateByShortcutId(@Param("shortcutId") Long shortcutId);
+
+}

--- a/src/main/java/com/YOGIITSU/repository/ShortcutRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/ShortcutRepository.java
@@ -1,0 +1,10 @@
+package com.YOGIITSU.repository;
+
+import com.YOGIITSU.entity.Shortcut;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ShortcutRepository extends JpaRepository<Shortcut, Long> {
+
+}

--- a/src/main/java/com/YOGIITSU/service/ShortcutService.java
+++ b/src/main/java/com/YOGIITSU/service/ShortcutService.java
@@ -1,0 +1,71 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.dto.ResponseDto.CoordinateDto;
+import com.YOGIITSU.dto.ResponseDto.ShortcutDetailResponseDto;
+import com.YOGIITSU.dto.ResponseDto.ShortcutListResponseDto;
+import com.YOGIITSU.entity.Shortcut;
+import com.YOGIITSU.entity.ShortcutCoordinate;
+import com.YOGIITSU.repository.ShortcutCoordinateRepository;
+import com.YOGIITSU.repository.ShortcutRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShortcutService {
+
+    private final ShortcutRepository shortcutRepository;
+    private final ShortcutCoordinateRepository shortcutCoordinateRepository;
+
+    /**
+     * 지름길 전체 리스트 조회
+     */
+    public List<ShortcutListResponseDto> getAllShortcuts() {
+        return shortcutRepository.findAll().stream()
+            .map(shortcut -> ShortcutListResponseDto.builder()
+                .shortcutId(shortcut.getShortcutId())
+                .pointA(shortcut.getPointA())
+                .pointB(shortcut.getPointB())
+                .distance(shortcut.getDistance())
+                .duration(shortcut.getDuration())
+                .build())
+            .toList();
+    }
+
+    /**
+     * 지름길 상세 정보 조회
+     */
+    public ShortcutDetailResponseDto getShortcutDetail(Long shortcutId) {
+
+        // 1. Shortcut 엔티티 조회
+        Shortcut shortcut = shortcutRepository.findById(shortcutId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 지름길이 존재하지 않습니다."));
+
+        // 2. ShortcutCoordinate 리스트 조회 (pointOrder순 정렬)
+        List<ShortcutCoordinate> coordinates = shortcutCoordinateRepository
+            .findCoordinateByShortcutId(shortcutId);
+
+        // 3. DTO 변환
+        List<CoordinateDto> coordinateDtos = coordinates.stream()
+            .map(coord -> new CoordinateDto(
+                coord.getLatitude(),
+                coord.getLongitude(),
+                coord.getPointOrder(),
+                coord.getDescription(),
+                coord.getTurnType(),
+                coord.getSegmentDistance(),
+                coord.getImageUrl()
+            ))
+            .toList();
+
+        return ShortcutDetailResponseDto.builder()
+            .shortcutId(shortcut.getShortcutId())
+            .pointA(shortcut.getPointA())
+            .pointB(shortcut.getPointB())
+            .distance(shortcut.getDistance())
+            .duration(shortcut.getDuration())
+            .coordinates(coordinateDtos)
+            .build();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/shortcut` → `develop`

### 변경 사항
- 지름길 전체 목록 및 상세 조회 API 구현
- `Shortcut`, `ShortcutCoordinate` 관련 Repository/Service/Controller 추가
- `ShortcutCoordinateRepository`에서 `pointOrder` 기준 정렬 쿼리 메서드 작성
- `TurnType` enum에 `@JsonValue` 적용하여 숫자 응답 처리
- Swagger 문서 태그(`@Tag`, `@Operation`) 작성

### 테스트 결과
- Swagger에서 `/shortcuts`, `/shortcuts/{shortcutId}` 응답 정상 확인
- DB에서 좌표값 수동 삽입 후 리스트 및 상세 정보 정상 조회
- `TurnType` enum 응답이 숫자(11, 12, 13)로 반환되는 것 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 모든 지름길 목록을 조회할 수 있는 API가 추가되었습니다.
  * 특정 지름길의 상세 정보를 조회할 수 있는 API가 추가되었습니다.
  * 각 지름길의 경로 좌표, 이동 거리, 소요 시간, 방향(직진/좌회전/우회전) 및 설명, 이미지 정보를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->