### PR TITLE
feat: 최근 검색어 최대 10개 제한 및 30일 지난 검색어 자동 삭제 기능 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/RecentSearchRepository.java
@@ -3,6 +3,7 @@ package com.YOGIITSU.repository;
 import com.YOGIITSU.entity.Building;
 import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.entity.RecentSearch;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -28,4 +29,6 @@ public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long
 	// 특정 회원과 건물에 대한 검색어 조회
 	List<RecentSearch> findByMemberAndBuildingId(Member member, Long buildingId);
 
+	// 30일 이전의 검색어 삭제
+	int deleteBySearchedAtBefore(LocalDateTime threshold);
 }

--- a/src/main/java/com/YOGIITSU/scheduler/SearchCleanupScheduler.java
+++ b/src/main/java/com/YOGIITSU/scheduler/SearchCleanupScheduler.java
@@ -1,0 +1,27 @@
+package com.YOGIITSU.scheduler;
+
+import com.YOGIITSU.repository.RecentSearchRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SearchCleanupScheduler {
+
+	private final RecentSearchRepository recentSearchRepository;
+
+	// 매일 새벽 3시에 실행
+	@Scheduled(cron = "0 0 3 * * *")
+	@Transactional
+	public void deleteOldSearches() {
+		LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+		int deletedCount = recentSearchRepository.deleteBySearchedAtBefore(threshold);
+
+		log.info("[RecentSearchCleanup] 30일 지난 검색어 {}건 삭제 완료 (기준일시: {})", deletedCount, threshold);
+	}
+}

--- a/src/main/java/com/YOGIITSU/service/RecentSearchService.java
+++ b/src/main/java/com/YOGIITSU/service/RecentSearchService.java
@@ -33,6 +33,13 @@ public class RecentSearchService {
 		recentSearchRepository.deleteByMemberAndKeyword(member, keyword);
 		recentSearchRepository.flush();
 
+		// 사용자별 최대 10개까지만 유지
+		List<RecentSearch> recentSearches = recentSearchRepository.findByMemberOrderBySearchedAtDesc(
+			member);
+		if (recentSearches.size() >= 10) {
+			recentSearchRepository.delete(recentSearches.getLast());
+		}
+
 		// alias 기반으로 building 매핑
 		Building matchedBuilding = buildingAliasRepository
 			.findFirstByAliasContainingOrderByIdAsc(keyword)
@@ -67,7 +74,8 @@ public class RecentSearchService {
 		Member member = memberRepository.findByMemberId(memberId)
 			.orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
-		List<RecentSearch> searchList = recentSearchRepository.findByMemberAndBuildingId(member, buildingId);
+		List<RecentSearch> searchList = recentSearchRepository.findByMemberAndBuildingId(member,
+			buildingId);
 		if (searchList.isEmpty()) {
 			throw new EntityNotFoundException("해당 건물과 연결된 검색어가 없습니다.");
 		}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/search` → `develop`

### 변경 사항
1. 사용자별 최근 검색어 최대 10개 제한
- saveSearchKeyword() 메서드 내에서 사용자별 검색어 개수를 체크

- 검색어가 10개 이상이면 가장 오래된 검색어를 삭제 후 최근 검색어 저장

2. 30일 이상 지난 검색어 자동 삭제 스케줄러 추가
- `@Scheduled(cron = "0 0 3 * * *")` → 매일 새벽 3시 실행

- 30일 이상 지난 검색어를 일괄 삭제

- 삭제 개수 및 기준 시간에 대한 로그 출력

### 테스트 결과
- 검색어 저장 시 11번째 입력 -> 가장 오래된 항목 삭제되고 새로운 검색어 저장됨 확인
- 검색어 개수 10개 이하일 때 -> 정상 저장됨, 삭제 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 30일 이상 지난 검색 기록이 매일 자동으로 삭제되는 정기 정리 기능이 추가되었습니다.

* **버그 수정**
  * 최근 검색어 저장 시 사용자별 최대 10개까지만 유지되도록 개선되었습니다. 10개를 초과할 경우 가장 오래된 검색어가 자동으로 삭제됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->