### PR TITLE
feat: 관리자 문의 답변 API 구현

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/AdminInquiryController.java
+++ b/src/main/java/com/YOGIITSU/controller/AdminInquiryController.java
@@ -1,0 +1,72 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.dto.RequestDto.AdminAnswerCreateRequestDto;
+import com.YOGIITSU.dto.RequestDto.AdminAnswerUpdateRequestDto;
+import com.YOGIITSU.dto.ResponseDto.InquiryResponseDto;
+import com.YOGIITSU.service.AdminInquiryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "관리자 문의 답변 API", description = "관리자 답변 등록 및 수정 기능 제공")
+@RestController
+@RequestMapping("/admin/inquiries")
+@RequiredArgsConstructor
+public class AdminInquiryController {
+
+    private final AdminInquiryService adminInquiryService;
+
+    /**
+     * 관리자 답변 등록 API
+     * - 문의 상태가 'PROCESSING'인 경우에만 등록 가능
+     * - 제목 및 내용이 비어있으면 예외 발생
+     */
+    @Operation(summary = "관리자 답변 등록")
+    @PostMapping("/{inquiryId}")
+    public ResponseEntity<InquiryResponseDto> createAnswer(
+        @PathVariable Long inquiryId,
+        @RequestBody @Valid AdminAnswerCreateRequestDto requestDto
+    ) {
+        InquiryResponseDto responseDto = adminInquiryService.createAnswer(inquiryId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    /**
+     * 문의 답변 수정 API
+     * - 상태가 'COMPLETE'인 문의에만 수정 가능
+     * - 기존 제목/내용을 새 값으로 갱신
+     */
+    @Operation(summary = "관리자 답변 수정")
+    @PutMapping("/{inquiryId}")
+    public ResponseEntity<InquiryResponseDto> updateAnswer(
+        @PathVariable Long inquiryId,
+        @RequestBody AdminAnswerUpdateRequestDto requestDto
+    ) {
+        InquiryResponseDto responseDto = adminInquiryService.updateAnswer(inquiryId, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    /**
+     * 문의글 삭제 API
+     * - 관리자 권한으로 사용자 문의글과 답변 모두 삭제
+     * - 상태와 관계없이 강제 삭제 가능
+     */
+    @Operation(summary = "문의 삭제")
+    @DeleteMapping("{inquiryId}")
+    public ResponseEntity<Void> deleteInquiryByAdmin(
+        @PathVariable Long inquiryId
+    ) {
+        adminInquiryService.deleteInquiryByAdmin(inquiryId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/YOGIITSU/dto/RequestDto/AdminAnswerCreateRequestDto.java
+++ b/src/main/java/com/YOGIITSU/dto/RequestDto/AdminAnswerCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.YOGIITSU.dto.RequestDto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AdminAnswerCreateRequestDto {
+
+    @NotBlank(message = "답변 제목을 입력해주세요.")
+    private String answerTitle;
+
+    @NotBlank(message = "답변 내용을 입력해주세요.")
+    private String answerContent;
+}

--- a/src/main/java/com/YOGIITSU/dto/RequestDto/AdminAnswerUpdateRequestDto.java
+++ b/src/main/java/com/YOGIITSU/dto/RequestDto/AdminAnswerUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.YOGIITSU.dto.RequestDto;
+
+import lombok.Getter;
+
+/**
+ * 관리자 답변 수정용 DTO
+ * - 제목 또는 내용 중 하나 이상 입력
+ * - 유효성 검사는 서비스 단에서 수동 처리
+ */
+@Getter
+public class AdminAnswerUpdateRequestDto {
+
+    private String answerTitle;
+    private String answerContent;
+
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/InquiryResponseDto.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 /**
  * 문의 상세 응답 DTO
- * - 제목, 내용, 답변, 작성일, 답변일 등 전체 정보 포함
+ * - 제목, 내용, 답변 내용, 작성일, 답변일 등 전체 정보 포함
  */
 @Getter
 @AllArgsConstructor
@@ -24,8 +24,9 @@ public class InquiryResponseDto {
     private Long authorId;
     private String authorName;
 
-    private String response;
-    private LocalDateTime responseAt;
+    private String answerTitle;
+    private String answerContent;
+    private LocalDateTime answerAt;
 
     public InquiryResponseDto(Inquiry inquiry) {
 
@@ -36,7 +37,8 @@ public class InquiryResponseDto {
         this.inquiryState = inquiry.getInquiryState();
         this.authorId = inquiry.getMember().getId();
         this.authorName = inquiry.getMember().getUserName();
-        this.response = inquiry.getResponse();
-        this.responseAt = inquiry.getResponseAt();
+        this.answerTitle = inquiry.getAnswerTitle();
+        this.answerContent = inquiry.getAnswerContent();
+        this.answerAt = inquiry.getAnswerAt();
     }
 }

--- a/src/main/java/com/YOGIITSU/entity/Inquiry.java
+++ b/src/main/java/com/YOGIITSU/entity/Inquiry.java
@@ -80,8 +80,12 @@ public class Inquiry {
      * 관리자 답변 수정
      */
     public void updateAnswer(String newTitle, String newContent) {
-        if (newTitle != null) this.answerTitle = newTitle;
-        if (newContent != null) this.answerContent = newContent;
+        if (newTitle != null && !newTitle.isBlank()) {
+            this.answerTitle = newTitle;
+        }
+        if (newContent != null && !newContent.isBlank()) {
+            this.answerContent = newContent;
+        }
         this.answerAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/YOGIITSU/entity/Inquiry.java
+++ b/src/main/java/com/YOGIITSU/entity/Inquiry.java
@@ -36,8 +36,11 @@ public class Inquiry {
     @Column(name = "inquiry_at", nullable = false, updatable = false)
     private LocalDateTime inquiryAt;
 
-    @Column(name = "response", columnDefinition = "TEXT")
-    private String response;
+    @Column(name = "response_title", columnDefinition = "TEXT")
+    private String responseTitle;
+
+    @Column(name = "response_content", columnDefinition = "TEXT")
+    private String responseContent;
 
     @Column(name = "response_at")
     private LocalDateTime responseAt;
@@ -67,14 +70,18 @@ public class Inquiry {
      * 답변 등록 및 답변일 설정
      */
     public void updateResponse(String response) {
-        this.response = response;
+        this.responseTitle = responseTitle;
+        this.responseContent = responseContent;
         this.responseAt = LocalDateTime.now();  // 답변 날짜 함께 갱신
+        this.inquiryState = InquiryState.COMPLETED;
     }
 
     /**
-     * 문의 상태 변경
+     * 관리자 답변 수정
      */
-    public void updateInquiryState(InquiryState newState) {
-        this.inquiryState = newState;
+    public void modifyResponse(String newTitle, String newContent) {
+        if (newTitle != null) this.responseTitle = newTitle;
+        if (newContent != null) this.responseContent = newContent;
+        this.responseAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/YOGIITSU/entity/Inquiry.java
+++ b/src/main/java/com/YOGIITSU/entity/Inquiry.java
@@ -36,14 +36,14 @@ public class Inquiry {
     @Column(name = "inquiry_at", nullable = false, updatable = false)
     private LocalDateTime inquiryAt;
 
-    @Column(name = "response_title", columnDefinition = "TEXT")
-    private String responseTitle;
+    @Column(name = "answer_title", columnDefinition = "TEXT")
+    private String answerTitle;
 
-    @Column(name = "response_content", columnDefinition = "TEXT")
-    private String responseContent;
+    @Column(name = "answer_content", columnDefinition = "TEXT")
+    private String answerContent;
 
-    @Column(name = "response_at")
-    private LocalDateTime responseAt;
+    @Column(name = "answer_at")
+    private LocalDateTime answerAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "inquiry_state", length = 50, nullable = false)
@@ -69,19 +69,19 @@ public class Inquiry {
     /**
      * 답변 등록 및 답변일 설정
      */
-    public void updateResponse(String response) {
-        this.responseTitle = responseTitle;
-        this.responseContent = responseContent;
-        this.responseAt = LocalDateTime.now();  // 답변 날짜 함께 갱신
+    public void createAnswer(String answerTitle, String answerContent) {
+        this.answerTitle = answerTitle;
+        this.answerContent = answerContent;
+        this.answerAt = LocalDateTime.now();  // 답변 날짜 함께 갱신
         this.inquiryState = InquiryState.COMPLETED;
     }
 
     /**
      * 관리자 답변 수정
      */
-    public void modifyResponse(String newTitle, String newContent) {
-        if (newTitle != null) this.responseTitle = newTitle;
-        if (newContent != null) this.responseContent = newContent;
-        this.responseAt = LocalDateTime.now();
+    public void updateAnswer(String newTitle, String newContent) {
+        if (newTitle != null) this.answerTitle = newTitle;
+        if (newContent != null) this.answerContent = newContent;
+        this.answerAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/YOGIITSU/service/AdminInquiryService.java
+++ b/src/main/java/com/YOGIITSU/service/AdminInquiryService.java
@@ -1,0 +1,124 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.dto.RequestDto.AdminAnswerCreateRequestDto;
+import com.YOGIITSU.dto.RequestDto.AdminAnswerUpdateRequestDto;
+import com.YOGIITSU.dto.ResponseDto.InquiryResponseDto;
+import com.YOGIITSU.entity.Inquiry;
+import com.YOGIITSU.entity.InquiryState;
+import com.YOGIITSU.jwt.CustomUserDetails;
+import com.YOGIITSU.repository.InquiryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminInquiryService {
+
+    private final InquiryRepository inquiryRepository;
+
+    /**
+     * 문의 답변 등록
+     * - 상태가 'PROCESSING'인 문의에만 등록 가능
+     * - 등록 시 상태를 'COMPLETE'로 변경
+     *
+     * @param inquiryId  답변할 문의 ID
+     * @param requestDto 답변 제목 및 내용
+     * @return InquiryResponseDto 등록 후 전체 문의 정보
+     */
+    @Transactional
+    public InquiryResponseDto createAnswer(Long inquiryId, AdminAnswerCreateRequestDto requestDto) {
+
+        checkAdminRole();
+
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 문의가 존재하지 않습니다."));
+
+        // 이미 답변 완료된 경우 예외 처리
+        if (inquiry.getInquiryState() == InquiryState.COMPLETED) {
+            throw new IllegalArgumentException("이미 답변이 등록된 문의입니다.");
+        }
+
+        String title = requestDto.getAnswerTitle();
+        String content = requestDto.getAnswerContent();
+
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("답변 제목은 비워둘 수 없습니다.");
+        }
+
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("답변 내용은 비워둘 수 없습니다.");
+        }
+
+        // 답변 등록
+        inquiry.createAnswer(title, content);
+        return new InquiryResponseDto(inquiry);
+    }
+
+    /**
+     * 문의 답변 수정
+     * - 상태가 'COMPLETE'인 문의에만 수정 가능
+     * - 제목이나 내용 중 하나라도 유효하면 수정
+     *
+     * @param inquiryId  수정할 문의 ID
+     * @param requestDto  수정할 제목 및 내용
+     * @return InquiryResponseDto 수정 후 전체 문의 정보
+     */
+    @Transactional
+    public InquiryResponseDto updateAnswer(Long inquiryId, AdminAnswerUpdateRequestDto requestDto) {
+
+        checkAdminRole();
+
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 문의가 존재하지 않습니다."));
+
+        // 답변이 등록되지 않은 경우 수정 불가
+        if (inquiry.getInquiryState() != InquiryState.COMPLETED) {
+            throw new IllegalArgumentException("아직 답변이 등록되지 않아 수정할 수 없습니다.");
+        }
+
+        String title = requestDto.getAnswerTitle();
+        String content = requestDto.getAnswerContent();
+
+        if ((title == null || title.isBlank()) && (content == null || content.isBlank())) {
+            throw new IllegalArgumentException("수정할 답변 제목 또는 내용을 입력하세요.");
+        }
+
+        inquiry.updateAnswer(title, content);
+        return new InquiryResponseDto(inquiry);
+    }
+
+    /**
+     * 문의글 삭제
+     * - 관리자 권한으로 문의글과 그에 대한 답변 전체 삭제
+     * - 상태와 무관하게 강제 삭제 가능
+     *
+     * @param inquiryId 삭제할 문의 ID
+     */
+    @Transactional
+    public void deleteInquiryByAdmin(Long inquiryId) {
+
+        checkAdminRole();
+
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 문의가 존재하지 않습니다."));
+
+        inquiryRepository.delete(inquiry);
+    }
+
+    private void checkAdminRole() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (!(auth.getPrincipal() instanceof CustomUserDetails userDetails)) {
+            throw new SecurityException("잘못된 사용자 정보입니다.");
+        }
+
+        if (!"ADMIN".equals(userDetails.getRole())) {
+            throw new SecurityException("관리자만 접근할 수 있습니다.");
+        }
+
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/admin-inquiry-api` → `develop`

### 변경 사항
- 관리자 전용 답변 기능 구현
    - 등록, 수정, 삭제
- 관리자 권한 체크 로직을 서비스 계층에서 수행
- 빈 제목/내용 입력 시 예외 처리 및 유효성 검증 적용
- **Inquiry 엔티티 리팩토링**
    - `response` -> `answer` 로 명칭 수정
    - 수정 메서드 `updateAnswer()` 조건 분기 개선
    - 답변 관련 필드 세분화
- **InquiryResponseDto 리팩토링**
    - 필드 명칭 및 응답 구조 일관성 있게 조정 

### 테스트 결과
- Swagger를 통해 관리자 답변 등록/수정/삭제 기능 정상 동작 확인
- 제목만 또는 내용만 수정 시 기존 데이터 유지됨 확인
- 관리자 외 사용자의 접근 차단 여부 확인