### PR TITLE
feat: 기존 비밀번호로 변경 시도 방지 로직 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -17,200 +17,201 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // 공통적인 예외 응답을 반환하는 메서드
-    private ResponseEntity<Map<String, String>> buildErrorResponse(String message,
-        HttpStatus status) {
-        Map<String, String> errorResponse = new HashMap<>();
-        errorResponse.put("message", message);
-        return ResponseEntity.status(status).body(errorResponse);
-    }
+	// 공통적인 예외 응답을 반환하는 메서드
+	private ResponseEntity<Map<String, String>> buildErrorResponse(String message,
+		HttpStatus status) {
+		Map<String, String> errorResponse = new HashMap<>();
+		errorResponse.put("message", message);
+		return ResponseEntity.status(status).body(errorResponse);
+	}
 
-    // 토큰이 없을 경우 예외 클래스 정의
-    @ExceptionHandler(MissingTokenException.class)
-    public ResponseEntity<Map<String, String>> handleMissingTokenException(
-        MissingTokenException e) {
-        return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
-    }
+	// 토큰이 없을 경우 예외 클래스 정의
+	@ExceptionHandler(MissingTokenException.class)
+	public ResponseEntity<Map<String, String>> handleMissingTokenException(
+		MissingTokenException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
+	}
 
-    // 유효하지 않은 토큰일 경우 예외 클래스 정의
-    @ExceptionHandler(InvalidTokenException.class)
-    public ResponseEntity<Map<String, String>> handleInvalidTokenException(
-        InvalidTokenException e) {
-        return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
-    }
+	// 유효하지 않은 토큰일 경우 예외 클래스 정의
+	@ExceptionHandler(InvalidTokenException.class)
+	public ResponseEntity<Map<String, String>> handleInvalidTokenException(
+		InvalidTokenException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
+	}
 
-    // 관리자 권한이 없을 경우 예외 클래스 정의
-    @ExceptionHandler(AdminAccessDeniedException.class)
-    public ResponseEntity<Map<String, String>> handleAdminAccessDeniedException(
-        AdminAccessDeniedException e) {
-        return buildErrorResponse(e.getMessage(), FORBIDDEN);
-    }
+	// 관리자 권한이 없을 경우 예외 클래스 정의
+	@ExceptionHandler(AdminAccessDeniedException.class)
+	public ResponseEntity<Map<String, String>> handleAdminAccessDeniedException(
+		AdminAccessDeniedException e) {
+		return buildErrorResponse(e.getMessage(), FORBIDDEN);
+	}
 
-    // 로그인 실패 (잘못된 아이디/비밀번호)
-    @ExceptionHandler(InvalidLoginException.class)
-    public ResponseEntity<Map<String, String>> handleInvalidLoginException(
-        InvalidLoginException e) {
-        return buildErrorResponse(e.getMessage(), UNAUTHORIZED);
-    }
+	// 로그인 실패 (잘못된 아이디/비밀번호)
+	@ExceptionHandler(InvalidLoginException.class)
+	public ResponseEntity<Map<String, String>> handleInvalidLoginException(
+		InvalidLoginException e) {
+		return buildErrorResponse(e.getMessage(), UNAUTHORIZED);
+	}
 
-    // 사용자를 찾을 수 없을 경우 예외 클래스 정의
-    @ExceptionHandler(MemberNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleMemberNotFoundException(
-        MemberNotFoundException e) {
-        return buildErrorResponse(e.getMessage(), FORBIDDEN);
-    }
+	// 사용자를 찾을 수 없을 경우 예외 클래스 정의
+	@ExceptionHandler(MemberNotFoundException.class)
+	public ResponseEntity<Map<String, String>> handleMemberNotFoundException(
+		MemberNotFoundException e) {
+		return buildErrorResponse(e.getMessage(), FORBIDDEN);
+	}
 
-    // 비밀번호가 일치하지 않을 경우 예외 처리
-    @ExceptionHandler(PasswordMismatchException.class)
-    public ResponseEntity<Map<String, String>> handlePasswordMismatchException(
-        PasswordMismatchException e) {
-        return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
-    }
+	// 비밀번호가 일치하지 않을 경우 예외 처리
+	@ExceptionHandler(PasswordMismatchException.class)
+	public ResponseEntity<Map<String, String>> handlePasswordMismatchException(
+		PasswordMismatchException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
+	}
 
-    // 새 비밀번호와 확인 비밀번호가 일치하지 않을 경우 예외 처리
-    @ExceptionHandler(PasswordNotEqualsException.class)
-    public ResponseEntity<Map<String, String>> handlePasswordNotEqualsException(
-        PasswordNotEqualsException e) {
-        return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
-    }
+	// 새 비밀번호와 확인 비밀번호가 일치하지 않을 경우 예외 처리
+	@ExceptionHandler(PasswordNotEqualsException.class)
+	public ResponseEntity<Map<String, String>> handlePasswordNotEqualsException(
+		PasswordNotEqualsException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
+	}
 
-    // 이메일 인증이 승인되지 않은 경우 예외 처리
-    @ExceptionHandler(EmailVerificationNotApprovedException.class)
-    public ResponseEntity<Map<String, String>> handleNotApproved(
-        EmailVerificationNotApprovedException e) {
-        return ResponseEntity.status(UNAUTHORIZED)
-            .body(Map.of("message", e.getMessage()));
-    }
+	// 이메일 인증이 승인되지 않은 경우 예외 처리
+	@ExceptionHandler(EmailVerificationNotApprovedException.class)
+	public ResponseEntity<Map<String, String>> handleNotApproved(
+		EmailVerificationNotApprovedException e) {
+		return ResponseEntity.status(UNAUTHORIZED)
+			.body(Map.of("message", e.getMessage()));
+	}
 
-    // 즐겨찾기 관련 예외 처리 추가
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleEntityNotFoundException(
-        EntityNotFoundException e) {
-        return buildErrorResponse(e.getMessage(), HttpStatus.NOT_FOUND);
-    }
+	// 즐겨찾기 관련 예외 처리 추가
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<Map<String, String>> handleEntityNotFoundException(
+		EntityNotFoundException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.NOT_FOUND);
+	}
 
-    // 회원가입 유효성 검사 예외 처리 추가
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleValidationException(
-        MethodArgumentNotValidException e) {
-        Map<String, String> errorResponse = new HashMap<>();
+	// 회원가입 유효성 검사 예외 처리 추가
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<Map<String, String>> handleValidationException(
+		MethodArgumentNotValidException e) {
+		Map<String, String> errorResponse = new HashMap<>();
 
-        // 첫 번째 오류 메시지만 추출하여 반환
-        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-        errorResponse.put("message", errorMessage);
+		// 첫 번째 오류 메시지만 추출하여 반환
+		String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+		errorResponse.put("message", errorMessage);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
-    }
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+	}
 
-    //IllegalArgumentException 발생 시 처리
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(
-        IllegalArgumentException e) {
-        return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
-    }
+	//IllegalArgumentException 발생 시 처리
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<Map<String, String>> handleIllegalArgumentException(
+		IllegalArgumentException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
+	}
 
-    // 이메일 전송 실패 예외 처리
-    @ExceptionHandler(MailException.class)
-    public ResponseEntity<Map<String, String>> handleMailException(MailException e) {
-        return buildErrorResponse("이메일 전송 중 오류가 발생했습니다: " + e.getMessage(),
-            HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+	// 이메일 전송 실패 예외 처리
+	@ExceptionHandler(MailException.class)
+	public ResponseEntity<Map<String, String>> handleMailException(MailException e) {
+		return buildErrorResponse("이메일 전송 중 오류가 발생했습니다: " + e.getMessage(),
+			HttpStatus.INTERNAL_SERVER_ERROR);
+	}
 
-    // 기타 예외 (MimeMessage 생성 오류 포함) 처리
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException e) {
-        return buildErrorResponse("서버 내부 오류 발생: " + e.getMessage(),
-            HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+	// 기타 예외 (MimeMessage 생성 오류 포함) 처리
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException e) {
+		return buildErrorResponse("서버 내부 오류 발생: " + e.getMessage(),
+			HttpStatus.INTERNAL_SERVER_ERROR);
+	}
 
-    // 건물 ID로 건물을 찾을 수 없는 경우 예외 처리
-    @ExceptionHandler(BuildingNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleBuildingNotFoundException(
-        BuildingNotFoundException e) {
-        return buildErrorResponse(e.getMessage(), HttpStatus.NOT_FOUND);
-    }
+	// 건물 ID로 건물을 찾을 수 없는 경우 예외 처리
+	@ExceptionHandler(BuildingNotFoundException.class)
+	public ResponseEntity<Map<String, String>> handleBuildingNotFoundException(
+		BuildingNotFoundException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.NOT_FOUND);
+	}
 
-    // 비밀번호 변경 시 기존 비밀번호와 동일한 비밀번호로 변경하려는 경우 예외 처리
-    @ExceptionHandler(SamePasswordException.class)
-    public ResponseEntity<Map<String, String>> handleSamePasswordException(
-        SamePasswordException e) {
-        return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
-    }
+	// 비밀번호 변경 시 기존 비밀번호와 동일한 비밀번호로 변경하려는 경우 예외 처리
+	@ExceptionHandler(SamePasswordException.class)
+	public ResponseEntity<Map<String, String>> handleSamePasswordException(
+		SamePasswordException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
+	}
 
-    public static class PasswordMismatchException extends RuntimeException {
+	public static class PasswordMismatchException extends RuntimeException {
 
-        public PasswordMismatchException() {
-            super("비밀번호가 일치하지 않습니다.");
-        }
-    }
+		public PasswordMismatchException() {
+			super("비밀번호가 일치하지 않습니다.");
+		}
+	}
 
-    public static class MissingTokenException extends RuntimeException {
+	public static class MissingTokenException extends RuntimeException {
 
-        public MissingTokenException() {
-            super("요청에 토큰이 포함되어 있지 않습니다.");
-        }
-    }
+		public MissingTokenException() {
+			super("요청에 토큰이 포함되어 있지 않습니다.");
+		}
+	}
 
-    public static class InvalidTokenException extends RuntimeException {
+	public static class InvalidTokenException extends RuntimeException {
 
-        public InvalidTokenException() {
-            super("유효하지 않은 토큰입니다.");
-        }
-    }
+		public InvalidTokenException() {
+			super("유효하지 않은 토큰입니다.");
+		}
+	}
 
-    public static class AdminAccessDeniedException extends RuntimeException {
+	public static class AdminAccessDeniedException extends RuntimeException {
 
-        public AdminAccessDeniedException() {
-            super("관리자 계정이 아닙니다.");
-        }
-    }
+		public AdminAccessDeniedException() {
+			super("관리자 계정이 아닙니다.");
+		}
+	}
 
-    public static class MemberNotFoundException extends RuntimeException {
+	public static class MemberNotFoundException extends RuntimeException {
 
-        public MemberNotFoundException() {
-            super("존재하지 않는 계정입니다.");
-        }
-    }
+		public MemberNotFoundException() {
+			super("존재하지 않는 계정입니다.");
+		}
+	}
 
-    public static class PasswordNotEqualsException extends RuntimeException {
+	public static class PasswordNotEqualsException extends RuntimeException {
 
-        public PasswordNotEqualsException() {
-            super("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.");
-        }
-    }
+		public PasswordNotEqualsException() {
+			super("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.");
+		}
+	}
 
-    public static class EmailVerificationNotApprovedException extends RuntimeException {
+	public static class EmailVerificationNotApprovedException extends RuntimeException {
 
-        public EmailVerificationNotApprovedException() {
-            super("이메일 인증이 완료되지 않았습니다.");
-        }
-    }
+		public EmailVerificationNotApprovedException() {
+			super("이메일 인증이 완료되지 않았습니다.");
+		}
+	}
 
-    public static class InvalidLoginException extends RuntimeException {
+	public static class InvalidLoginException extends RuntimeException {
 
-        public InvalidLoginException() {
-            super("아이디 또는 비밀번호가 잘못되었습니다.");
-        }
-    }
+		public InvalidLoginException() {
+			super("아이디 또는 비밀번호가 잘못되었습니다.");
+		}
+	}
 
-    //로그인 여부 확인
-    @ExceptionHandler(UnauthenticatedAccessException.class)
-    public ResponseEntity<Map<String, String>> handleUnauthenticatedAccess(
-        UnauthenticatedAccessException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-            .body(Map.of("message", e.getMessage()));
-    }
+	//로그인 여부 확인
+	@ExceptionHandler(UnauthenticatedAccessException.class)
+	public ResponseEntity<Map<String, String>> handleUnauthenticatedAccess(
+		UnauthenticatedAccessException e) {
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+			.body(Map.of("message", e.getMessage()));
+	}
 
-    public static class UnauthenticatedAccessException extends RuntimeException {
+	public static class UnauthenticatedAccessException extends RuntimeException {
 
-        public UnauthenticatedAccessException() {
-            super("로그인된 사용자만 접근 가능합니다.");
-        }
-    }
+		public UnauthenticatedAccessException() {
+			super("로그인된 사용자만 접근 가능합니다.");
+		}
+	}
 
-    public static class SamePasswordException extends RuntimeException {
-        public SamePasswordException() {
-            super("기존 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다.");
-        }
-    }
+	public static class SamePasswordException extends RuntimeException {
+
+		public SamePasswordException() {
+			super("기존 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다.");
+		}
+	}
 }

--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -30,130 +30,130 @@ import java.util.Map;
 @RequestMapping("/members")
 public class MemberController {
 
-    private final MemberService memberService;
-    private final JwtTokenProvider jwtTokenProvider;
+	private final MemberService memberService;
+	private final JwtTokenProvider jwtTokenProvider;
 
-    private static final String NO_EMAIL_FOUND = "가입 이력이 없는 이메일입니다.";
-    private static final String EMAIL_MATCH_FOUND = "이메일 정보와 일치하는 아이디가 있습니다.";
-    private static final String MEMBER_DELETION_SUCCESS = "님의 회원 탈퇴가 완료되었습니다.";
+	private static final String NO_EMAIL_FOUND = "가입 이력이 없는 이메일입니다.";
+	private static final String EMAIL_MATCH_FOUND = "이메일 정보와 일치하는 아이디가 있습니다.";
+	private static final String MEMBER_DELETION_SUCCESS = "님의 회원 탈퇴가 완료되었습니다.";
 
-    /**
-     * 로그인 API
-     *
-     * @param memberLoginRequestDto 요청 데이터 (아이디, 비밀번호)
-     * @return TokenInfo JWT 토큰 정보
-     */
-    @Operation(summary = "로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
-    @PostMapping("/login")
-    public ResponseEntity<Map<String, Object>> login(
-        @RequestBody MemberLoginRequestDto memberLoginRequestDto) {
-        return memberService.login(
-            memberLoginRequestDto.getMemberId(),
-            memberLoginRequestDto.getPassword()
-        );
-    }
+	/**
+	 * 로그인 API
+	 *
+	 * @param memberLoginRequestDto 요청 데이터 (아이디, 비밀번호)
+	 * @return TokenInfo JWT 토큰 정보
+	 */
+	@Operation(summary = "로그인", description = "아이디와 비밀번호를 이용해 로그인합니다.")
+	@PostMapping("/login")
+	public ResponseEntity<Map<String, Object>> login(
+		@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
+		return memberService.login(
+			memberLoginRequestDto.getMemberId(),
+			memberLoginRequestDto.getPassword()
+		);
+	}
 
 
-    /**
-     * 아이디 찾기 API
-     *
-     * @param request 요청 데이터 (이메일)
-     * @return 아이디 찾기 결과
-     */
-    @Operation(summary = "아이디 찾기", description = "이메일을 기반으로 등록된 아이디를 조회합니다.")
-    @PostMapping("/find-id")
-    public ResponseEntity<FindMemberIdResponseDto> findId(
-        @RequestBody FindMemberIdRequestDto request) {
-        String email = request.getEmail();
-        String memberId = memberService.findIdByEmail(email);
+	/**
+	 * 아이디 찾기 API
+	 *
+	 * @param request 요청 데이터 (이메일)
+	 * @return 아이디 찾기 결과
+	 */
+	@Operation(summary = "아이디 찾기", description = "이메일을 기반으로 등록된 아이디를 조회합니다.")
+	@PostMapping("/find-id")
+	public ResponseEntity<FindMemberIdResponseDto> findId(
+		@RequestBody FindMemberIdRequestDto request) {
+		String email = request.getEmail();
+		String memberId = memberService.findIdByEmail(email);
 
-        FindMemberIdResponseDto response = FindMemberIdResponseDto.builder()
-            .status(memberId != null ? "success" : "error")
-            .id(memberId)
-            .message(memberId == null ? NO_EMAIL_FOUND : EMAIL_MATCH_FOUND)
-            .build();
+		FindMemberIdResponseDto response = FindMemberIdResponseDto.builder()
+			.status(memberId != null ? "success" : "error")
+			.id(memberId)
+			.message(memberId == null ? NO_EMAIL_FOUND : EMAIL_MATCH_FOUND)
+			.build();
 
-        return memberId == null ? ResponseEntity.status(HttpStatus.NOT_FOUND).body(response)
-            : ResponseEntity.ok(response);
-    }
+		return memberId == null ? ResponseEntity.status(HttpStatus.NOT_FOUND).body(response)
+			: ResponseEntity.ok(response);
+	}
 
-    /**
-     * 회원 탈퇴 API
-     *
-     * @param request HTTP 요청 객체
-     */
-    @Operation(summary = "회원 탈퇴", description = "비밀번호 확인 후 JWT 토큰 기반으로 회원 탈퇴 처리합니다.")
-    @DeleteMapping("/delete")
-    public ResponseEntity<Map<String, String>> deleteMember(
-        @RequestBody PasswordCheckRequestDto request, HttpServletRequest httpRequest) {
-        // 1. 요청에서 JWT 토큰 추출
-        String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+	/**
+	 * 회원 탈퇴 API
+	 *
+	 * @param request HTTP 요청 객체
+	 */
+	@Operation(summary = "회원 탈퇴", description = "비밀번호 확인 후 JWT 토큰 기반으로 회원 탈퇴 처리합니다.")
+	@DeleteMapping("/delete")
+	public ResponseEntity<Map<String, String>> deleteMember(
+		@RequestBody PasswordCheckRequestDto request, HttpServletRequest httpRequest) {
+		// 1. 요청에서 JWT 토큰 추출
+		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
 
-        // 2. 토큰이 없으면 예외 발생
-        if (accessToken == null) {
-            throw new MissingTokenException();
-        }
+		// 2. 토큰이 없으면 예외 발생
+		if (accessToken == null) {
+			throw new MissingTokenException();
+		}
 
-        // 3. 토큰이 유효한지 확인, 유효하지 않으면 예외 발생
-        if (!jwtTokenProvider.validateToken(accessToken)) {
-            throw new InvalidTokenException();
-        }
+		// 3. 토큰이 유효한지 확인, 유효하지 않으면 예외 발생
+		if (!jwtTokenProvider.validateToken(accessToken)) {
+			throw new InvalidTokenException();
+		}
 
-        // 4. 유효한 토큰이라면 사용자 ID 추출
-        String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
+		// 4. 유효한 토큰이라면 사용자 ID 추출
+		String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
 
-        // 5. 회원 탈퇴 처리
-        memberService.deleteMember(memberId, request.getPassword());
+		// 5. 회원 탈퇴 처리
+		memberService.deleteMember(memberId, request.getPassword());
 
-        // 6. 탈퇴 성공 메시지 반환
-        Map<String, String> response = new HashMap<>();
-        response.put("message", memberId + MEMBER_DELETION_SUCCESS);
-        return ResponseEntity.ok(response);
-    }
+		// 6. 탈퇴 성공 메시지 반환
+		Map<String, String> response = new HashMap<>();
+		response.put("message", memberId + MEMBER_DELETION_SUCCESS);
+		return ResponseEntity.ok(response);
+	}
 
-    /**
-     * 비밀번호 변경 API
-     *
-     * @param requestDto  새로운 비밀번호와 확인 비밀번호
-     * @param httpRequest HTTP 요청 객체
-     * @return 비밀번호 변경 결과
-     */
-    @Operation(summary = "비밀번호 변경", description = "로그인된 상태에서 새 비밀번호로 변경합니다.")
-    @PatchMapping("/change-password")
-    public ResponseEntity<Map<String, String>> changePassword(
-        @RequestBody ChangePasswordRequestDto requestDto, HttpServletRequest httpRequest) {
+	/**
+	 * 비밀번호 변경 API
+	 *
+	 * @param requestDto  새로운 비밀번호와 확인 비밀번호
+	 * @param httpRequest HTTP 요청 객체
+	 * @return 비밀번호 변경 결과
+	 */
+	@Operation(summary = "비밀번호 변경", description = "로그인된 상태에서 새 비밀번호로 변경합니다.")
+	@PatchMapping("/change-password")
+	public ResponseEntity<Map<String, String>> changePassword(
+		@RequestBody ChangePasswordRequestDto requestDto, HttpServletRequest httpRequest) {
 
-        // 1. JWT 토큰 추출 및 유효성 검사
-        String accessToken = jwtTokenProvider.resolveToken(httpRequest);
-        if (accessToken == null || !jwtTokenProvider.validateToken(accessToken)) {
-            throw new InvalidTokenException();
-        }
+		// 1. JWT 토큰 추출 및 유효성 검사
+		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
+		if (accessToken == null || !jwtTokenProvider.validateToken(accessToken)) {
+			throw new InvalidTokenException();
+		}
 
-        // 2. 현재 인증된 사용자 가져오기
-        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-        String memberId = authentication.getName();
+		// 2. 현재 인증된 사용자 가져오기
+		Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+		String memberId = authentication.getName();
 
-        // 3. 비밀번호 변경 처리
-        memberService.changePassword(memberId, requestDto.getNewPassword(),
-            requestDto.getConfirmPassword());
+		// 3. 비밀번호 변경 처리
+		memberService.changePassword(memberId, requestDto.getNewPassword(),
+			requestDto.getConfirmPassword());
 
-        // 4. 성공 메시지 반환
-        return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
-    }
+		// 4. 성공 메시지 반환
+		return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
+	}
 
-    /**
-     * 비밀번호 찾기 (재설정) 로그인되지 않은 상태 -> 이메일 인증 완료 여부를 기반으로 비밀번호 재설정 허용
-     *
-     * @param requestDto 요청 데이터 (이메일, 새 비밀번호, 확인 비밀번호)
-     * @return 비밀번호 재설정 결과
-     */
-    @Operation(summary = "비밀번호 찾기 (재설정)", description = "비밀번호를 찾기 위해 이메일 인증을 완료한 사용자가 비밀번호를 재설정합니다.")
-    @PostMapping("/find-password")
-    public ResponseEntity<Map<String, String>> resetPassword(
-        @RequestBody PasswordResetRequestDto requestDto) {
+	/**
+	 * 비밀번호 찾기 (재설정) 로그인되지 않은 상태 -> 이메일 인증 완료 여부를 기반으로 비밀번호 재설정 허용
+	 *
+	 * @param requestDto 요청 데이터 (이메일, 새 비밀번호, 확인 비밀번호)
+	 * @return 비밀번호 재설정 결과
+	 */
+	@Operation(summary = "비밀번호 찾기 (재설정)", description = "비밀번호를 찾기 위해 이메일 인증을 완료한 사용자가 비밀번호를 재설정합니다.")
+	@PostMapping("/find-password")
+	public ResponseEntity<Map<String, String>> resetPassword(
+		@RequestBody PasswordResetRequestDto requestDto) {
 
-        memberService.resetPasswordAfterEmailVerification(requestDto);
+		memberService.resetPasswordAfterEmailVerification(requestDto);
 
-        return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
-    }
+		return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
+	}
 }

--- a/src/main/java/com/YOGIITSU/repository/MemberRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/MemberRepository.java
@@ -15,7 +15,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	// memberId를 가진 Member 엔티티에 쓰기 잠금을 걸어 동시성 문제를 방지
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("SELECT m FROM Member m WHERE m.memberId = :memberId") // memberId로 Member를 조회
+	@Query("SELECT m FROM Member m WHERE m.memberId = :memberId")
+	// memberId로 Member를 조회
 	Optional<Member> findByMemberIdWithLock(@Param("memberId") String memberId);
 
 	// 이메일을 기준으로 회원을 찾는 메서드 추가

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -64,8 +64,10 @@ public class MemberService {
 
 			// 3. 생성된 토큰을 헤더에 담아 반환
 			HttpHeaders headers = new HttpHeaders();
-			headers.set("Authorization", "Bearer " + tokenInfo.getAccessToken());   // AccessToken → Authorization 헤더
-			headers.set("X-Refresh-Token", tokenInfo.getRefreshToken());           // RefreshToken → X-Refresh-Token 헤더
+			headers.set("Authorization",
+				"Bearer " + tokenInfo.getAccessToken());   // AccessToken → Authorization 헤더
+			headers.set("X-Refresh-Token",
+				tokenInfo.getRefreshToken());           // RefreshToken → X-Refresh-Token 헤더
 
 			Map<String, Object> responseBody = new HashMap<>();
 			responseBody.put("message", "로그인 성공");


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`feature/prevent-same-password` → `develop`

### 변경 사항

- 동일한 비밀번호로 비밀번호 변경/재설정 시도 시 예외 발생 처리 추가
- `SamePasswordException` 예외 클래스 및 GlobalExceptionHandler 등록
- `changePassword()` 및 `resetPasswordAfterEmailVerification()` 메서드에 검증 로직 추가
- 일부 클래스의 코드 포맷 정리

### 테스트 결과
<img width="2094" height="321" alt="image" src="https://github.com/user-attachments/assets/c5886e5e-24c5-4c60-a4a2-4368fec1922f" />

- 동일한 비밀번호로 변경 시 `400 Bad Request` 응답 및 에러 메시지 확인됨
- 정상적인 비밀번호 변경/재설정은 문제없이 작동함
