### PR TITLE
Fix: 이메일 변경 기능 개선 및 인증 관련 리팩토링

### DIFF
--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -137,6 +137,13 @@ public class GlobalExceptionHandler {
 		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
 	}
 
+	// 이메일 변경 시 기존 이메일과 동일한 이메일로 변경하려는 경우 예외 처리
+	@ExceptionHandler(SameEmailException.class)
+	public ResponseEntity<Map<String, String>> handleSameEmailException(
+		SameEmailException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
 	public static class PasswordMismatchException extends RuntimeException {
 
 		public PasswordMismatchException() {
@@ -212,6 +219,13 @@ public class GlobalExceptionHandler {
 
 		public SamePasswordException() {
 			super("기존 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다.");
+		}
+	}
+
+	public static class SameEmailException extends RuntimeException {
+
+		public SameEmailException() {
+			super("기존 이메일과 동일한 이메일로는 변경할 수 없습니다.");
 		}
 	}
 }

--- a/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
+++ b/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
@@ -39,7 +39,7 @@ public class EmailVerificationController {
 
             // 2. 입력 값과 토큰 비교
             if (!tokenCode.equals(requestDto.getCode())) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(EmailVerificationResponseDto.builder()
                         .status("error")
                         .message("인증 코드가 일치하지 않습니다.")

--- a/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
+++ b/src/main/java/com/YOGIITSU/controller/EmailVerificationController.java
@@ -18,53 +18,53 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class EmailVerificationController {
 
-    private final EmailVerificationJwtProvider emailJwtProvider;
-    private final EmailService emailService;
+	private final EmailVerificationJwtProvider emailJwtProvider;
+	private final EmailService emailService;
 
-    @Operation(
-        summary = "이메일 인증 코드 검증",
-        description = "사용자가 입력한 인증 코드를 토큰에 포함된 코드와 비교하고, 인증 성공 시 DB의 승인 상태를 true로 변경합니다."
-    )
-    @PostMapping("/verify")
-    public ResponseEntity<EmailVerificationResponseDto> verifyCode(
-        @RequestHeader("X-Email-Verification-Token") String token,
-        @RequestBody EmailVerificationRequestDto requestDto) {
+	@Operation(
+		summary = "이메일 인증 코드 검증",
+		description = "사용자가 입력한 인증 코드를 토큰에 포함된 코드와 비교하고, 인증 성공 시 DB의 승인 상태를 true로 변경합니다."
+	)
+	@PostMapping("/verify")
+	public ResponseEntity<EmailVerificationResponseDto> verifyCode(
+		@RequestHeader("X-Email-Verification-Token") String token,
+		@RequestBody EmailVerificationRequestDto requestDto) {
 
-        try {
-            // 1. JWT 토큰 검증
-            Claims claims = emailJwtProvider.parseEmailToken(token)
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 토큰입니다."));
-            String tokenEmail = claims.getSubject();
-            String tokenCode = claims.get("code", String.class);
+		try {
+			// 1. JWT 토큰 검증
+			Claims claims = emailJwtProvider.parseEmailToken(token)
+				.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 토큰입니다."));
+			String tokenEmail = claims.getSubject();
+			String tokenCode = claims.get("code", String.class);
 
-            // 2. 입력 값과 토큰 비교
-            if (!tokenCode.equals(requestDto.getCode())) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(EmailVerificationResponseDto.builder()
-                        .status("error")
-                        .message("인증 코드가 일치하지 않습니다.")
-                        .email(null)
-                        .build());
-            }
+			// 2. 입력 값과 토큰 비교
+			if (!tokenCode.equals(requestDto.getCode())) {
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+					.body(EmailVerificationResponseDto.builder()
+						.status("error")
+						.message("인증 코드가 일치하지 않습니다.")
+						.email(null)
+						.build());
+			}
 
-            // isApproved = true로 바꾼다.
-            emailService.approveEmailCode(tokenEmail, tokenCode);
+			// isApproved = true로 바꾼다.
+			emailService.approveEmailCode(tokenEmail, tokenCode);
 
-            // 5. 응답 메시지 생성 및 반환
-            return ResponseEntity.ok(
-                EmailVerificationResponseDto.builder()
-                    .status("success")
-                    .message("이메일 인증에 성공하였습니다.")
-                    .email(tokenEmail)
-                    .build());
+			// 5. 응답 메시지 생성 및 반환
+			return ResponseEntity.ok(
+				EmailVerificationResponseDto.builder()
+					.status("success")
+					.message("이메일 인증에 성공하였습니다.")
+					.email(tokenEmail)
+					.build());
 
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(EmailVerificationResponseDto.builder()
-                    .status("error")
-                    .message(e.getMessage())
-                    .email(null)
-                    .build());
-        }
-    }
+		} catch (IllegalArgumentException e) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(EmailVerificationResponseDto.builder()
+					.status("error")
+					.message(e.getMessage())
+					.email(null)
+					.build());
+		}
+	}
 }

--- a/src/main/java/com/YOGIITSU/service/EmailService.java
+++ b/src/main/java/com/YOGIITSU/service/EmailService.java
@@ -8,8 +8,8 @@ import com.YOGIITSU.repository.EmailMessageRepository;
 import com.YOGIITSU.repository.MemberRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
+import java.security.SecureRandom;
 import java.util.Locale;
-import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
@@ -41,7 +41,7 @@ public class EmailService {
 
 	// 6자리 숫자 인증 코드 생성
 	public String generateVerificationCode() {
-		Random random = new Random();
+		SecureRandom random = new SecureRandom();
 		int code = 100000 + random.nextInt(900000); // 100000 ~ 999999
 		return String.valueOf(code);
 	}

--- a/src/main/java/com/YOGIITSU/service/EmailService.java
+++ b/src/main/java/com/YOGIITSU/service/EmailService.java
@@ -31,217 +31,218 @@ import com.YOGIITSU.config.handler.GlobalExceptionHandler.SameEmailException;
 @RequiredArgsConstructor
 public class EmailService {
 
-    private final JavaMailSender javaMailSender;
-    private final SpringTemplateEngine templateEngine;
-    private final EmailMessageRepository emailMessageRepository;
-    private final MemberRepository memberRepository;
-    private final EmailVerificationJwtProvider emailJwtProvider;
-    private final EmailProperties emailProperties;
-    private final JwtTokenProvider jwtTokenProvider;
+	private final JavaMailSender javaMailSender;
+	private final SpringTemplateEngine templateEngine;
+	private final EmailMessageRepository emailMessageRepository;
+	private final MemberRepository memberRepository;
+	private final EmailVerificationJwtProvider emailJwtProvider;
+	private final EmailProperties emailProperties;
+	private final JwtTokenProvider jwtTokenProvider;
 
-    // 6자리 숫자 인증 코드 생성
-    public String generateVerificationCode() {
-        Random random = new Random();
-        int code = 100000 + random.nextInt(900000); // 100000 ~ 999999
-        return String.valueOf(code);
-    }
+	// 6자리 숫자 인증 코드 생성
+	public String generateVerificationCode() {
+		Random random = new Random();
+		int code = 100000 + random.nextInt(900000); // 100000 ~ 999999
+		return String.valueOf(code);
+	}
 
-    //인증 메일 정보를 DB에 저장
-    @Transactional
-    public void saveEmailMessage(EmailMessage emailMessage) {
-        emailMessageRepository.save(emailMessage);
-    }
+	//인증 메일 정보를 DB에 저장
+	@Transactional
+	public void saveEmailMessage(EmailMessage emailMessage) {
+		emailMessageRepository.save(emailMessage);
+	}
 
-    // 이메일 전송 (인증 코드 포함)
-    public void sendMail(EmailMessage emailMessage, String type) {
-        // 도메인 제한 체크
-        if (!isAllowedEmailDomain(emailMessage.getEmail())) {
-            throw new IllegalArgumentException(
-                "suwon.ac.kr, naver.com, gmail.com 도메인만 인증할 수 있습니다.");
-        }
+	// 이메일 전송 (인증 코드 포함)
+	public void sendMail(EmailMessage emailMessage, String type) {
+		// 도메인 제한 체크
+		if (!isAllowedEmailDomain(emailMessage.getEmail())) {
+			throw new IllegalArgumentException(
+				"suwon.ac.kr, naver.com, gmail.com 도메인만 인증할 수 있습니다.");
+		}
 
-        try {
-            MimeMessageHelper mimeMessageHelper = createMimeMessage(emailMessage,
-                emailMessage.getCode(), type);
-            javaMailSender.send(mimeMessageHelper.getMimeMessage());
-            log.info("메일 전송 성공: {}", emailMessage.getEmail());
+		try {
+			MimeMessageHelper mimeMessageHelper = createMimeMessage(emailMessage,
+				emailMessage.getCode(), type);
+			javaMailSender.send(mimeMessageHelper.getMimeMessage());
+			log.info("메일 전송 성공: {}", emailMessage.getEmail());
 
-        } catch (MailException e) {
-            log.error("메일 전송 실패: {}", e.getMessage());
-            throw new RuntimeException("메일 전송 중 오류가 발생했습니다: " + e.getMessage(), e);
-        }
-    }
+		} catch (MailException e) {
+			log.error("메일 전송 실패: {}", e.getMessage());
+			throw new RuntimeException("메일 전송 중 오류가 발생했습니다: " + e.getMessage(), e);
+		}
+	}
 
-    // 허용된 이메일 도메인인지 확인
-    private boolean isAllowedEmailDomain(String email) {
-        String normalized = email.trim().toLowerCase(Locale.ROOT);
-        return emailProperties.allowedDomains().stream()
-            .anyMatch(domain -> normalized.endsWith("@" + domain));
-    }
+	// 허용된 이메일 도메인인지 확인
+	private boolean isAllowedEmailDomain(String email) {
+		String normalized = email.trim().toLowerCase(Locale.ROOT);
+		return emailProperties.allowedDomains().stream()
+			.anyMatch(domain -> normalized.endsWith("@" + domain));
+	}
 
-    // MimeMessage 생성
-    private MimeMessageHelper createMimeMessage(EmailMessage emailMessage, String authNum,
-        String type) {
-        try {
-            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(
-                javaMailSender.createMimeMessage(), false, "UTF-8");
+	// MimeMessage 생성
+	private MimeMessageHelper createMimeMessage(EmailMessage emailMessage, String authNum,
+		String type) {
+		try {
+			MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(
+				javaMailSender.createMimeMessage(), false, "UTF-8");
 
-            mimeMessageHelper.setTo(emailMessage.getEmail());
-            mimeMessageHelper.setSubject("YOGIITSU 인증 코드: " + authNum);
-            mimeMessageHelper.setText(setContext(authNum, type), true);
+			mimeMessageHelper.setTo(emailMessage.getEmail());
+			mimeMessageHelper.setSubject("YOGIITSU 인증 코드: " + authNum);
+			mimeMessageHelper.setText(setContext(authNum, type), true);
 
-            return mimeMessageHelper;
-        } catch (Exception e) {
-            throw new RuntimeException("MimeMessage 생성 중 오류 발생: " + e.getMessage(), e);
-        }
-    }
+			return mimeMessageHelper;
+		} catch (Exception e) {
+			throw new RuntimeException("MimeMessage 생성 중 오류 발생: " + e.getMessage(), e);
+		}
+	}
 
-    /**
-     * HTML 메일 본문 생성 (Thymeleaf)
-     */
-    private String setContext(String code, String type) {
-        Context context = new Context();
-        context.setVariable("code", code);
-        return templateEngine.process(type, context);
-    }
+	/**
+	 * HTML 메일 본문 생성 (Thymeleaf)
+	 */
+	private String setContext(String code, String type) {
+		Context context = new Context();
+		context.setVariable("code", code);
+		return templateEngine.process(type, context);
+	}
 
-    // 인증 목적에 따른 이메일 유효성 검사
-    public void validateEmailRequest(String email, EmailPurpose purpose, Authentication auth) {
-        if (email == null || email.trim().isEmpty()) {
-            throw new IllegalArgumentException("이메일 주소는 필수입니다.");
-        }
+	// 인증 목적에 따른 이메일 유효성 검사
+	public void validateEmailRequest(String email, EmailPurpose purpose, Authentication auth) {
+		if (email == null || email.trim().isEmpty()) {
+			throw new IllegalArgumentException("이메일 주소는 필수입니다.");
+		}
 
-        if (!isAllowedEmailDomain(email)) {
-            throw new IllegalArgumentException("suwon.ac.kr, naver.com, gmail.com 도메인만 인증할 수 있습니다.");
-        }
+		if (!isAllowedEmailDomain(email)) {
+			throw new IllegalArgumentException(
+				"suwon.ac.kr, naver.com, gmail.com 도메인만 인증할 수 있습니다.");
+		}
 
-        // 인증이 필요한 목적인지 확인
-        if (purpose.isRequiresAuth()) {
-            checkAuthentication(auth);
-        }
+		// 인증이 필요한 목적인지 확인
+		if (purpose.isRequiresAuth()) {
+			checkAuthentication(auth);
+		}
 
-        if (purpose.isMustExist()) {
-            checkEmailExists(email);
+		if (purpose.isMustExist()) {
+			checkEmailExists(email);
 
-            if (purpose == EmailPurpose.EMAIL_CHANGE_OLD) {
-                validateEmailForChangeOld(email, auth);
-            }
+			if (purpose == EmailPurpose.EMAIL_CHANGE_OLD) {
+				validateEmailForChangeOld(email, auth);
+			}
 
-        } else {
-            if (purpose == EmailPurpose.EMAIL_CHANGE_NEW) {
-                String memberId = auth.getName();
-                Member member = memberRepository.findByMemberId(memberId)
-                    .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+		} else {
+			if (purpose == EmailPurpose.EMAIL_CHANGE_NEW) {
+				String memberId = auth.getName();
+				Member member = memberRepository.findByMemberId(memberId)
+					.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
-                if (member.getEmail().trim().equalsIgnoreCase(email.trim())) {
-                    throw new SameEmailException();
-                }
-            }
+				if (member.getEmail().trim().equalsIgnoreCase(email.trim())) {
+					throw new SameEmailException();
+				}
+			}
 
-            if (memberRepository.existsByEmail(email)) {
-                throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
-            }
-        }
-    }
+			if (memberRepository.existsByEmail(email)) {
+				throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+			}
+		}
+	}
 
-    // 인증이 필요한 요청에 대해 인증 여부 검사
-    public void checkAuthentication(Authentication auth) {
-        if (auth == null || !auth.isAuthenticated()) {
-            throw new IllegalArgumentException("로그인이 필요한 요청입니다.");
-        }
-    }
+	// 인증이 필요한 요청에 대해 인증 여부 검사
+	public void checkAuthentication(Authentication auth) {
+		if (auth == null || !auth.isAuthenticated()) {
+			throw new IllegalArgumentException("로그인이 필요한 요청입니다.");
+		}
+	}
 
-    // 이메일 변경 전 기존 이메일 검증 (로그인한 사용자와 입력 이메일 비교)
-    public void validateEmailForChangeOld(String email, Authentication auth) {
-        // 1. DB에 해당 이메일 존재 여부 확인 추가
-        checkEmailExists(email);
+	// 이메일 변경 전 기존 이메일 검증 (로그인한 사용자와 입력 이메일 비교)
+	public void validateEmailForChangeOld(String email, Authentication auth) {
+		// 1. DB에 해당 이메일 존재 여부 확인 추가
+		checkEmailExists(email);
 
-        // 2. 로그인된 사용자 정보 조회
-        String memberId = auth.getName();
-        Member member = memberRepository.findByMemberId(memberId)
-            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+		// 2. 로그인된 사용자 정보 조회
+		String memberId = auth.getName();
+		Member member = memberRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
-        // 3. 입력한 이메일이 로그인된 사용자의 현재 이메일과 일치하는지 확인
-        if (!member.getEmail().equals(email)) {
-            throw new IllegalArgumentException("이메일 정보가 일치하지 않습니다.");
-        }
-    }
+		// 3. 입력한 이메일이 로그인된 사용자의 현재 이메일과 일치하는지 확인
+		if (!member.getEmail().equals(email)) {
+			throw new IllegalArgumentException("이메일 정보가 일치하지 않습니다.");
+		}
+	}
 
-    @Transactional
-    public void approveEmailCode(String email, String code) {
-        EmailMessage message = findEmailMessage(email, code);
-        approveAndSave(message);
-    }
+	@Transactional
+	public void approveEmailCode(String email, String code) {
+		EmailMessage message = findEmailMessage(email, code);
+		approveAndSave(message);
+	}
 
-    // 이메일 변경 수행 (인증 코드 검증 -> 승인 -> 사용자 이메일 변경)
-    @Transactional
-    public void changeEmail(String token, HttpServletRequest request) {
-        // 1. AccessToken 추출 및 유효성 검사
-        String accessToken = jwtTokenProvider.resolveToken(request);
-        if (accessToken == null || !jwtTokenProvider.validateToken(accessToken)) {
-            throw new IllegalArgumentException("유효하지 않은 로그인 토큰입니다.");
-        }
+	// 이메일 변경 수행 (인증 코드 검증 -> 승인 -> 사용자 이메일 변경)
+	@Transactional
+	public void changeEmail(String token, HttpServletRequest request) {
+		// 1. AccessToken 추출 및 유효성 검사
+		String accessToken = jwtTokenProvider.resolveToken(request);
+		if (accessToken == null || !jwtTokenProvider.validateToken(accessToken)) {
+			throw new IllegalArgumentException("유효하지 않은 로그인 토큰입니다.");
+		}
 
-        // 2. 인증 객체 획득
-        Authentication auth = jwtTokenProvider.getAuthentication(accessToken);
+		// 2. 인증 객체 획득
+		Authentication auth = jwtTokenProvider.getAuthentication(accessToken);
 
-        // 3. JWT 토큰 파싱하여 새 이메일 및 인증 코드 추출
-        Claims claims = emailJwtProvider.parseEmailToken(token)
-            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 토큰입니다."));
+		// 3. JWT 토큰 파싱하여 새 이메일 및 인증 코드 추출
+		Claims claims = emailJwtProvider.parseEmailToken(token)
+			.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 토큰입니다."));
 
-        String newEmail = claims.getSubject();
-        String code = claims.get("code", String.class);
+		String newEmail = claims.getSubject();
+		String code = claims.get("code", String.class);
 
-        // 4. 인증 코드 검증 및 승인 처리
-        EmailMessage message = verifyEmailCode(newEmail, code);
-        approveAndSave(message);
+		// 4. 인증 코드 검증 및 승인 처리
+		EmailMessage message = verifyEmailCode(newEmail, code);
+		approveAndSave(message);
 
-        // 5. 사용자 정보 조회
-        String memberId = auth.getName();
-        Member member = memberRepository.findByMemberIdWithLock(memberId)
-            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+		// 5. 사용자 정보 조회
+		String memberId = auth.getName();
+		Member member = memberRepository.findByMemberIdWithLock(memberId)
+			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
-        // 6. 기존 이메일과 동일한지 검사
-        if (member.getEmail().trim().equalsIgnoreCase(newEmail.trim())) {
-            throw new SameEmailException();
-        }
+		// 6. 기존 이메일과 동일한지 검사
+		if (member.getEmail().trim().equalsIgnoreCase(newEmail.trim())) {
+			throw new SameEmailException();
+		}
 
-        // 7. 새 이메일 중복 여부 검사
-        if (memberRepository.existsByEmail(newEmail)) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
-        }
+		// 7. 새 이메일 중복 여부 검사
+		if (memberRepository.existsByEmail(newEmail)) {
+			throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+		}
 
-        // 8. 사용자 이메일 변경
-        member.setEmail(newEmail);
-        memberRepository.save(member);
-        log.info("이메일 변경 완료 - memberId: {}, newEmail: {}", memberId, newEmail);
-    }
+		// 8. 사용자 이메일 변경
+		member.setEmail(newEmail);
+		memberRepository.save(member);
+		log.info("이메일 변경 완료 - memberId: {}, newEmail: {}", memberId, newEmail);
+	}
 
-    // 인증 코드 검증 (존재 + 만료 여부)
-    public EmailMessage verifyEmailCode(String email, String code) {
-        EmailMessage message = findEmailMessage(email, code);
-        if (message.getExpiresAt().isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException("인증 코드가 만료되었습니다.");
-        }
-        return message;
-    }
+	// 인증 코드 검증 (존재 + 만료 여부)
+	public EmailMessage verifyEmailCode(String email, String code) {
+		EmailMessage message = findEmailMessage(email, code);
+		if (message.getExpiresAt().isBefore(LocalDateTime.now())) {
+			throw new IllegalArgumentException("인증 코드가 만료되었습니다.");
+		}
+		return message;
+	}
 
-    // 이메일과 코드로 EmailMessage 조회
-    private EmailMessage findEmailMessage(String email, String code) {
-        return emailMessageRepository.findByEmailAndCode(email, code)
-            .orElseThrow(() -> new IllegalArgumentException("인증 코드가 만료되었습니다. 인증 코드를 재전송해 주세요."));
-    }
+	// 이메일과 코드로 EmailMessage 조회
+	private EmailMessage findEmailMessage(String email, String code) {
+		return emailMessageRepository.findByEmailAndCode(email, code)
+			.orElseThrow(() -> new IllegalArgumentException("인증 코드가 만료되었습니다. 인증 코드를 재전송해 주세요."));
+	}
 
-    // 인증 승인 처리 및 저장
-    private void approveAndSave(EmailMessage message) {
-        message.approve();
-        emailMessageRepository.save(message);
-    }
+	// 인증 승인 처리 및 저장
+	private void approveAndSave(EmailMessage message) {
+		message.approve();
+		emailMessageRepository.save(message);
+	}
 
-    // 이메일 존재 여부 확인
-    private void checkEmailExists(String email) {
-        if (!memberRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("해당 이메일로 가입된 계정이 존재하지 않습니다.");
-        }
-    }
+	// 이메일 존재 여부 확인
+	private void checkEmailExists(String email) {
+		if (!memberRepository.existsByEmail(email)) {
+			throw new IllegalArgumentException("해당 이메일로 가입된 계정이 존재하지 않습니다.");
+		}
+	}
 }

--- a/src/main/java/com/YOGIITSU/service/EmailService.java
+++ b/src/main/java/com/YOGIITSU/service/EmailService.java
@@ -24,6 +24,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import java.time.LocalDateTime;
 import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.entity.EmailPurpose;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.SameEmailException;
 
 @Slf4j
 @Service
@@ -38,14 +39,11 @@ public class EmailService {
     private final EmailProperties emailProperties;
     private final JwtTokenProvider jwtTokenProvider;
 
-    // 6자리 인증 코드 생성 (A~Z 알파벳)
+    // 6자리 숫자 인증 코드 생성
     public String generateVerificationCode() {
         Random random = new Random();
-        StringBuilder key = new StringBuilder();
-        for (int i = 0; i < 6; i++) {
-            key.append((char) (random.nextInt(26) + 65)); // A~Z
-        }
-        return key.toString();
+        int code = 100000 + random.nextInt(900000); // 100000 ~ 999999
+        return String.valueOf(code);
     }
 
     //인증 메일 정보를 DB에 저장
@@ -113,6 +111,10 @@ public class EmailService {
             throw new IllegalArgumentException("이메일 주소는 필수입니다.");
         }
 
+        if (!isAllowedEmailDomain(email)) {
+            throw new IllegalArgumentException("suwon.ac.kr, naver.com, gmail.com 도메인만 인증할 수 있습니다.");
+        }
+
         // 인증이 필요한 목적인지 확인
         if (purpose.isRequiresAuth()) {
             checkAuthentication(auth);
@@ -126,6 +128,16 @@ public class EmailService {
             }
 
         } else {
+            if (purpose == EmailPurpose.EMAIL_CHANGE_NEW) {
+                String memberId = auth.getName();
+                Member member = memberRepository.findByMemberId(memberId)
+                    .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+                if (member.getEmail().trim().equalsIgnoreCase(email.trim())) {
+                    throw new SameEmailException();
+                }
+            }
+
             if (memberRepository.existsByEmail(email)) {
                 throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
             }
@@ -184,19 +196,24 @@ public class EmailService {
         EmailMessage message = verifyEmailCode(newEmail, code);
         approveAndSave(message);
 
-        // 5. 새 이메일 중복 여부 검사
-        if (memberRepository.existsByEmail(newEmail)) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
-        }
-
-        // 6. 사용자 이메일 변경
+        // 5. 사용자 정보 조회
         String memberId = auth.getName();
         Member member = memberRepository.findByMemberIdWithLock(memberId)
             .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
+        // 6. 기존 이메일과 동일한지 검사
+        if (member.getEmail().trim().equalsIgnoreCase(newEmail.trim())) {
+            throw new SameEmailException();
+        }
+
+        // 7. 새 이메일 중복 여부 검사
+        if (memberRepository.existsByEmail(newEmail)) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        // 8. 사용자 이메일 변경
         member.setEmail(newEmail);
         memberRepository.save(member);
-
         log.info("이메일 변경 완료 - memberId: {}, newEmail: {}", memberId, newEmail);
     }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/email-change` → `develop`

### 변경 사항
- 인증 코드 형식을 기존 영문 포함에서 숫자 6자리로 변경
- SameEmailException을 생성하여, 이메일 변경 시 기존 이메일과 동일한 경우 예외 처리
- EmailVerificationController에서 인증 실패 시 응답 코드 401 → 400 으로 수정 (프론트 재입력 문제 해결 목적)

### 테스트 결과
- 기존 이메일로 변경 시 SameEmailException 발생 확인
- 인증 코드 발급 시 6자리 숫자 코드로 정상 전송됨
- Swagger에서 인증 코드 오입력 → 재입력 시 정상적으로 처리됨 (400 응답 확인)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 기존 이메일과 동일한 이메일로 변경 시도를 차단하는 기능이 추가되었습니다. 동일한 이메일로 변경할 경우 명확한 오류 메시지가 제공됩니다.

* **버그 수정**
  * 이메일 인증 코드 불일치 시 반환되는 HTTP 상태 코드가 401(UNAUTHORIZED)에서 400(BAD REQUEST)로 변경되었습니다.

* **기능 개선**
  * 이메일 인증 코드가 6자리 숫자로 변경되었습니다.
  * 허용되지 않은 도메인의 이메일은 요청 단계에서 즉시 거부됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->