### PR TITLE
feat: 소셜 로그인 provider 구분 처리 (Google/Kakao/Local)

### DIFF
--- a/src/main/java/com/YOGIITSU/entity/Member.java
+++ b/src/main/java/com/YOGIITSU/entity/Member.java
@@ -44,6 +44,9 @@ public class Member implements UserDetails {
     @Column(name = "join_at", nullable = false)
     private LocalDateTime joinAt; // 가입일
 
+    @Column(name = "provider", length = 20)
+    private String provider; // "local", "google", "kakao" 등을 저장
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Inquiry> inquiries;
 

--- a/src/main/java/com/YOGIITSU/service/GoogleAuthService.java
+++ b/src/main/java/com/YOGIITSU/service/GoogleAuthService.java
@@ -37,7 +37,7 @@ public class GoogleAuthService {
 			String name = (String) payload.get("name");
 
 			// 3. UserService를 통해 사용자 조회 또는 신규 가입 처리
-			Member member = userService.processOAuthUser(email, name);
+			Member member = userService.processOAuthUser("google", email, name);
 
 			// 4. 우리 서비스의 인증 토큰 생성을 위한 Authentication 객체 생성
 			CustomUserDetails userDetails = new CustomUserDetails(

--- a/src/main/java/com/YOGIITSU/service/KakaoAuthService.java
+++ b/src/main/java/com/YOGIITSU/service/KakaoAuthService.java
@@ -46,7 +46,7 @@ public class KakaoAuthService {
 			String nickname = (String) profile.get("nickname");
 
 			// 3. UserService를 통해 사용자 조회 또는 신규 가입 처리
-			Member member = userService.processOAuthUser(email, nickname);
+			Member member = userService.processOAuthUser("kakao", email, nickname);
 
 			// 4. 자체 인증 토큰 생성을 위한 Authentication 객체 생성
 			CustomUserDetails userDetails = new CustomUserDetails(

--- a/src/main/java/com/YOGIITSU/service/SignUpService.java
+++ b/src/main/java/com/YOGIITSU/service/SignUpService.java
@@ -80,6 +80,7 @@ public class SignUpService {
 			.userName(dto.getUserName())
 			.role("USER")  // 반드시 ROLE_ 접두사
 			.joinAt(java.time.LocalDateTime.now())
+			.provider("local") // 로컬 회원가입을 나타내는 provider
 			.build();
 
 		// 9. DB 저장

--- a/src/main/java/com/YOGIITSU/service/UserService.java
+++ b/src/main/java/com/YOGIITSU/service/UserService.java
@@ -2,6 +2,7 @@ package com.YOGIITSU.service;
 
 import com.YOGIITSU.entity.Member;
 import com.YOGIITSU.repository.MemberRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,27 +19,43 @@ public class UserService {
 	private final PasswordEncoder passwordEncoder; // 비밀번호 암호화를 위해 주입
 
 	@Transactional
-	public Member processOAuthUser(String email, String name) {
-		// 이메일로 기존 사용자가 있는지 조회합니다.
-		return memberRepository.findByEmail(email)
-			.orElseGet(() -> {
-				//이메일 도메인으로 소셜 타입을 구분
-				String provider = (email != null && email.endsWith("@gmail.com")) ? "google_" : "kakao_";
-				String memberId = provider + UUID.randomUUID().toString().substring(0, 8);
+	public Member processOAuthUser(String provider, String email, String name) {
+		// 1. 이메일로 사용자를 조회합니다.
+		Optional<Member> memberOpt = memberRepository.findByEmail(email);
 
-				// 소셜 로그인 사용자는 비밀번호를 사용하지 않으므로, 임의의 값을 암호화하여 저장합니다.
-				String randomPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+		if (memberOpt.isPresent()) {
+			// 2. 이메일이 이미 존재할 경우
+			Member member = memberOpt.get();
 
-				Member newMember = Member.builder()
-					.memberId(memberId)
-					.email(email)
-					.userName(name)
-					.password(randomPassword)
-					.role("USER")
-					.joinAt(LocalDateTime.now())
-					.build();
+			// 3. 저장된 provider와 현재 로그인하려는 provider가 다른지 확인
+			if (member.getProvider() != null && !member.getProvider().equals(provider)) {
+				// provider가 다르면, 계정 탈취 위험이 있으므로 에러를 발생시킵니다.
+				throw new RuntimeException(
+					"이미 " + member.getProvider() + " 계정으로 가입된 이메일입니다. 해당 방식으로 로그인해주세요.");
+			}
+			// provider가 같으면, 기존 사용자이므로 그대로 반환합니다.
+			return member;
+		} else {
+			// 4. 신규 사용자이면 새로 생성합니다.
+			return createNewMember(provider, email, name);
+		}
+	}
 
-				return memberRepository.save(newMember);
-			});
+	// 신규 멤버 생성 로직은 동일
+	private Member createNewMember(String provider, String email, String name) {
+		String memberId = provider + "_" + UUID.randomUUID().toString().substring(0, 8);
+		String randomPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+
+		Member newMember = Member.builder()
+			.memberId(memberId)
+			.email(email)
+			.userName(name)
+			.password(randomPassword)
+			.role("USER")
+			.provider(provider)
+			.joinAt(LocalDateTime.now())
+			.build();
+
+		return memberRepository.save(newMember);
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`feature/social-login` → `develop`

### 변경 사항

**소셜 로그인 시 이메일만으로 사용자를 식별하여 발생할 수 있는 계정 탈취 보안 취약점을 해결했습니다.**

- **`Member` 테이블에 `provider` 컬럼 추가**
    - 사용자의 가입 경로(`local`, `google`, `kakao`)를 명시적으로 저장하기 위해 `provider` 컬럼을 DB에 추가했습니다.
- **`UserService` 로직 수정**
    - 소셜 로그인 요청 시, DB에서 이메일로 사용자를 찾은 후 해당 계정의 `provider` 정보를 확인하는 로직을 추가했습니다.
    - 만약 이미 가입된 계정의 `provider`와 현재 로그인하려는 소셜 플랫폼의 `provider`가 일치하지 않을 경우, 로그인을 차단하고 예외를 발생시키도록 변경하여 계정 탈취를 방지했습니다.
- **기존 회원가입 로직 수정**
    - 자체 회원가입(`local`) 시 `provider` 필드에 "local" 값을 저장하도록 `MemberService`를 수정했습니다.

### 테스트 결과

- 스웨거로 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 소셜/로컬 로그인 계정에 인증 제공자 정보가 반영되어 계정이 일관되게 관리됩니다.
* 버그 수정
  * 동일 이메일을 서로 다른 로그인 제공자에서 사용하는 경우가 차단되어 로그인/회원가입 과정의 충돌이 해소되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->