### PR TITLE
feat: 선택 정류장 기준 전체 시간표를 동적으로 생성

### DIFF
--- a/src/main/java/com/YOGIITSU/service/ShuttleService.java
+++ b/src/main/java/com/YOGIITSU/service/ShuttleService.java
@@ -125,8 +125,9 @@ public class ShuttleService {
 			.toList();
 
 		// 전체 시간표와 노선 정보를 가져옵니다.
-		List<String> fullTimeTableString = departureTimes.stream()
-			.map(time -> time.format(timeFormatter))
+		List<String> fullTimeTableForStop = departureTimes.stream()
+			.map(departureTime -> estimateArrivalAtStop(departureTime, stopIndex)) // 각 출발 시간에 대한 도착 시간 계산
+			.map(arrivalTime -> arrivalTime.format(timeFormatter))
 			.toList();
 
 		List<RouteStopResponseDto> fullRouteObjectList = route.stream()
@@ -134,7 +135,7 @@ public class ShuttleService {
 			.toList();
 
 		// 새로 만든 통합 DTO로 모든 정보를 담아 반환합니다.
-		return new ShuttleScheduleDetailResponseDto(stopId, stopName, upcomingShuttles, fullTimeTableString,
+		return new ShuttleScheduleDetailResponseDto(stopId, stopName, upcomingShuttles, fullTimeTableForStop,
 			fullRouteObjectList);
 	}
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/update-timetable-by-stop` → `develop`

### 변경 사항
**정류장 기준 전체 시간표 제공**

- 기존에는 첫 출발지 기준 시간표만 제공했으나, 이제는 **선택된 정류장 기준의 전체 도착 시간표**(`fullTimeTable`)를 동적으로 생성하여 반환하도록 개선했습니다.
### 테스트 결과
- 정상 동작 확인: 각 정류장 ID (STOP_01 ~ STOP_08)로 GET 요청했을 때, 200 OK 상태 코드와 함께 의도된 구조와 데이터(정류장별 fullTimeTable 포함)가 정확히 반환됨을 확인했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 정류장별 전체 시간표가 ‘출발 시각’ 나열에서 ‘해당 정류장의 도착 시각’ 기준으로 개선되었습니다. 각 출발 시간에 대한 정류장 도착 시각을 계산해 보기 쉽게 표시하여, 특정 정류장에서 도착하는 모든 운행을 한눈에 확인할 수 있습니다. 기존의 가까운 셔틀 및 전체 노선 정보 표시는 변함 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->