### PR TITLE
feat: Apple 로그인 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ out/
 
 ### macOS ###
 .DS_Store
+
+
+### Application YML (local/dev config) ###
+src/main/resources/application-*.yml
+application-*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
+	implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+	implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/com/YOGIITSU/config/SecurityConfig.java
+++ b/src/main/java/com/YOGIITSU/config/SecurityConfig.java
@@ -101,6 +101,8 @@ public class SecurityConfig {
 		configuration.setExposedHeaders(Arrays.asList("Authorization", "verify")); // 노출할 응답 헤더
 		configuration.setAllowCredentials(true); // 자격 증명 허용
 
+		configuration.setExposedHeaders(Arrays.asList("Authorization", "verify", "X-Refresh-Token"));
+
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", configuration);
 		return source;

--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -159,27 +159,6 @@ public class GlobalExceptionHandler {
 		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
 	}
 
-	// Apple identityToken이 유효하지 않을 경우 예외 처리
-	@ExceptionHandler(AppleTokenInvalidException.class)
-	public ResponseEntity<Map<String, String>> handleAppleTokenInvalid(
-		AppleTokenInvalidException e) {
-		return buildErrorResponse(e.getMessage(), UNAUTHORIZED);
-	}
-
-	// Apple 공개키를 찾을 수 없을 경우 예외 처리
-	@ExceptionHandler(ApplePublicKeyNotFoundException.class)
-	public ResponseEntity<Map<String, String>> handleAppleKeyNotFound(
-		ApplePublicKeyNotFoundException e) {
-		return buildErrorResponse(e.getMessage(), UNAUTHORIZED);
-	}
-
-	// Apple 토큰 검증 과정에서 내부 오류가 발생한 경우 예외 처리
-	@ExceptionHandler(AppleVerificationException.class)
-	public ResponseEntity<Map<String, String>> handleAppleVerificationError(
-		AppleVerificationException e) {
-		return buildErrorResponse(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-	}
-
 	// 셔틀 정류장 ID로 정류장을 찾을 수 없는 경우 예외 처리
 	@ExceptionHandler(ShuttleStopNotFoundException.class)
 	public ResponseEntity<Map<String, String>> handleShuttleStopNotFoundException(

--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -144,6 +144,27 @@ public class GlobalExceptionHandler {
 		return buildErrorResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
 	}
 
+	// Apple identityToken이 유효하지 않을 경우 예외 처리
+	@ExceptionHandler(AppleTokenInvalidException.class)
+	public ResponseEntity<Map<String, String>> handleAppleTokenInvalid(
+		AppleTokenInvalidException e) {
+		return buildErrorResponse(e.getMessage(), UNAUTHORIZED);
+	}
+
+	// Apple 공개키를 찾을 수 없을 경우 예외 처리
+	@ExceptionHandler(ApplePublicKeyNotFoundException.class)
+	public ResponseEntity<Map<String, String>> handleAppleKeyNotFound(
+		ApplePublicKeyNotFoundException e) {
+		return buildErrorResponse(e.getMessage(), UNAUTHORIZED);
+	}
+
+	// Apple 토큰 검증 과정에서 내부 오류가 발생한 경우 예외 처리
+	@ExceptionHandler(AppleVerificationException.class)
+	public ResponseEntity<Map<String, String>> handleAppleVerificationError(
+		AppleVerificationException e) {
+		return buildErrorResponse(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
 	public static class PasswordMismatchException extends RuntimeException {
 
 		public PasswordMismatchException() {
@@ -227,5 +248,20 @@ public class GlobalExceptionHandler {
 		public SameEmailException() {
 			super("기존 이메일과 동일한 이메일로는 변경할 수 없습니다.");
 		}
+	}
+
+	public static class AppleTokenInvalidException extends RuntimeException {
+
+        public AppleTokenInvalidException() { super("유효하지 않은 Apple identityToken 입니다."); }
+	}
+
+	public static class ApplePublicKeyNotFoundException extends RuntimeException {
+
+        public ApplePublicKeyNotFoundException() { super("Apple 공개키를 찾을 수 없습니다."); }
+	}
+
+	public static class AppleVerificationException extends RuntimeException {
+
+        public AppleVerificationException() { super("Apple 토큰 검증 중 오류가 발생했습니다."); }
 	}
 }

--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -250,18 +250,22 @@ public class GlobalExceptionHandler {
 		}
 	}
 
+	// Apple 관련 예외 클래스
 	public static class AppleTokenInvalidException extends RuntimeException {
-
-        public AppleTokenInvalidException() { super("유효하지 않은 Apple identityToken 입니다."); }
+		public AppleTokenInvalidException() {
+			super("유효하지 않은 Apple identityToken 입니다.");
+		}
 	}
 
 	public static class ApplePublicKeyNotFoundException extends RuntimeException {
-
-        public ApplePublicKeyNotFoundException() { super("Apple 공개키를 찾을 수 없습니다."); }
+		public ApplePublicKeyNotFoundException() {
+			super("Apple 공개키를 찾을 수 없습니다.");
+		}
 	}
 
 	public static class AppleVerificationException extends RuntimeException {
-
-        public AppleVerificationException() { super("Apple 토큰 검증 중 오류가 발생했습니다."); }
+		public AppleVerificationException() {
+			super("Apple 토큰 검증 중 오류가 발생했습니다.");
+		}
 	}
 }

--- a/src/main/java/com/YOGIITSU/controller/AppleAuthController.java
+++ b/src/main/java/com/YOGIITSU/controller/AppleAuthController.java
@@ -1,0 +1,55 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.dto.RequestDto.AppleLoginRequestDto;
+import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
+import com.YOGIITSU.dto.ResponseDto.UserResponseDto;
+import com.YOGIITSU.service.AppleAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "소셜 로그인 API", description = "애플 소셜 로그인 기능을 제공합니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AppleAuthController {
+
+    private final AppleAuthService appleAuthService;
+
+    @Operation(
+        summary = "Apple 소셜 로그인",
+        description = "애플 authorizationCode로 로그인을 처리하고, 자체 JWT를 발급합니다."
+    )
+    @PostMapping("/apple")
+    public ResponseEntity<Map<String, Object>> loginWithApple(
+        @RequestBody AppleLoginRequestDto requestDto) {
+        // 1. 서비스 호출 → 자체 JWT 발급
+        TokenResponseDto tokenInfo = appleAuthService.loginWithApple(
+            requestDto.getAuthorizationCode());
+
+        // 2. 응답 헤더에 JWT 세팅
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + tokenInfo.getAccessToken());
+        headers.set("X-Refresh-Token", tokenInfo.getRefreshToken());
+
+        // 3. 응답 바디 데이터 구성
+        UserResponseDto userDto = tokenInfo.getUser();
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("message", "로그인 성공");
+        responseBody.put("userId", userDto.getId());
+        responseBody.put("role", userDto.getRole());
+
+        // 4. 최종 응답 반환
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(responseBody);
+    }
+}

--- a/src/main/java/com/YOGIITSU/dto/RequestDto/AppleLoginRequestDto.java
+++ b/src/main/java/com/YOGIITSU/dto/RequestDto/AppleLoginRequestDto.java
@@ -1,0 +1,26 @@
+package com.YOGIITSU.dto.RequestDto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AppleLoginRequestDto {
+
+    @NotBlank(message = "identityToken은 필수입니다.")
+    private String identityToken;
+
+    @Size(max = 128)
+    private String rawNonce;
+
+    @JsonCreator
+    public AppleLoginRequestDto(@JsonProperty("identityToken") String identityToken,
+        @JsonProperty("rawNonce") String rawNonce) {
+        this.identityToken = identityToken;
+        this.rawNonce = rawNonce;
+    }
+}

--- a/src/main/java/com/YOGIITSU/dto/RequestDto/AppleLoginRequestDto.java
+++ b/src/main/java/com/YOGIITSU/dto/RequestDto/AppleLoginRequestDto.java
@@ -3,7 +3,6 @@ package com.YOGIITSU.dto.RequestDto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,16 +10,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AppleLoginRequestDto {
 
-    @NotBlank(message = "identityToken은 필수입니다.")
-    private String identityToken;
-
-    @Size(max = 128)
-    private String rawNonce;
+    @NotBlank(message = "authorizationCode은 필수입니다.")
+    private String authorizationCode;
 
     @JsonCreator
-    public AppleLoginRequestDto(@JsonProperty("identityToken") String identityToken,
-        @JsonProperty("rawNonce") String rawNonce) {
-        this.identityToken = identityToken;
-        this.rawNonce = rawNonce;
+    public AppleLoginRequestDto(@JsonProperty("authorizationCode") String authorizationCode) {
+        this.authorizationCode = authorizationCode;
     }
 }

--- a/src/main/java/com/YOGIITSU/service/AppleAuthService.java
+++ b/src/main/java/com/YOGIITSU/service/AppleAuthService.java
@@ -61,18 +61,21 @@ public class AppleAuthService {
                 throw new IllegalArgumentException("Apple 토큰 응답이 비어있음");
             }
 
+            // 3. id_token 검증 및 claims 추출
             String idToken = (String) response.getBody().get("id_token");
             Map<String, Object> claims = AppleJwtUtil.verifyAndGetClaims(idToken);
 
             String sub = (String) claims.get("sub");
             String email = (String) claims.get("email");
 
+            // 4. 사용자 등록/갱신 처리
             Member member = userService.processOAuthUser(
                 "apple",
                 (email != null) ? email : sub + "@appleuser.com",
                 "AppleUser_" + sub.substring(0, 6)
             );
 
+            // 5. 인증 객체 생성
             CustomUserDetails userDetails = new CustomUserDetails(
                 member.getId(),
                 member.getMemberId(),
@@ -87,7 +90,9 @@ public class AppleAuthService {
                 userDetails, null, userDetails.getAuthorities()
             );
 
+            // 6. JWT 발급
             return jwtTokenProvider.generateToken(authentication);
+            
         } catch (Exception e) {
             log.error("Apple 로그인 실패 : {}", e.getMessage());
             throw new org.springframework.security.authentication.AuthenticationServiceException(

--- a/src/main/java/com/YOGIITSU/service/AppleAuthService.java
+++ b/src/main/java/com/YOGIITSU/service/AppleAuthService.java
@@ -9,11 +9,14 @@ import com.YOGIITSU.util.ClientSecretProvider;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -30,7 +33,15 @@ public class AppleAuthService {
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
     private final ClientSecretProvider clientSecretProvider;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000); // 연결 타임아웃 5초
+        factory.setReadTimeout(10000);   // 응답 타임아웃 10초
+        return new RestTemplate(factory);
+    }
 
     @Transactional
     public TokenResponseDto loginWithApple(String authorizationCode) {
@@ -92,7 +103,7 @@ public class AppleAuthService {
 
             // 6. JWT 발급
             return jwtTokenProvider.generateToken(authentication);
-            
+
         } catch (Exception e) {
             log.error("Apple 로그인 실패 : {}", e.getMessage());
             throw new org.springframework.security.authentication.AuthenticationServiceException(

--- a/src/main/java/com/YOGIITSU/service/AppleAuthService.java
+++ b/src/main/java/com/YOGIITSU/service/AppleAuthService.java
@@ -1,0 +1,94 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.dto.ResponseDto.TokenResponseDto;
+import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.jwt.CustomUserDetails;
+import com.YOGIITSU.jwt.JwtTokenProvider;
+import com.YOGIITSU.util.AppleJwtUtil;
+import com.YOGIITSU.util.ClientSecretProvider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AppleAuthService {
+
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ClientSecretProvider clientSecretProvider;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Transactional
+    public TokenResponseDto loginWithApple(String authorizationCode) {
+        try {
+            // 1. client_secret 생성
+            String clientSecret = clientSecretProvider.createClientSecret();
+
+            // 2. Apple 서버 토큰 교환 요청
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("client_id", clientSecretProvider.getClientId());
+            body.add("client_secret", clientSecret);
+            body.add("code", authorizationCode);
+            body.add("grant_type", "authorization_code");
+
+            HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                "https://appleid.apple.com/auth/token",
+                HttpMethod.POST,
+                request,
+                Map.class
+            );
+
+            String idToken = (String) response.getBody().get("id_token");
+            Map<String, Object> claims = AppleJwtUtil.verifyAndGetClaims(idToken);
+
+            String sub = (String) claims.get("sub");
+            String email = (String) claims.get("email");
+
+            Member member = userService.processOAuthUser(
+                "apple",
+                (email != null) ? email : sub + "@appleuser.com",
+                "AppleUser_" + sub.substring(0, 6)
+            );
+
+            CustomUserDetails userDetails = new CustomUserDetails(
+                member.getId(),
+                member.getMemberId(),
+                member.getUserName(),
+                member.getEmail(),
+                member.getPassword(),
+                member.getRole(),
+                member.getAuthorities()
+            );
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities()
+            );
+
+            return jwtTokenProvider.generateToken(authentication);
+        } catch (Exception e) {
+            log.error("Apple 로그인 실패 : {}", e.getMessage());
+            throw new org.springframework.security.authentication.AuthenticationServiceException(
+                "Apple 로그인 실패", e
+            );
+        }
+    }
+}

--- a/src/main/java/com/YOGIITSU/service/AppleAuthService.java
+++ b/src/main/java/com/YOGIITSU/service/AppleAuthService.java
@@ -75,6 +75,21 @@ public class AppleAuthService {
             // 3. id_token 검증 및 claims 추출
             String idToken = (String) response.getBody().get("id_token");
             Map<String, Object> claims = AppleJwtUtil.verifyAndGetClaims(idToken);
+            
+            String iss = (String) claims.get("iss");
+            if (!"https://appleid.apple.com".equals(iss)) {
+                throw new com.YOGIITSU.config.handler.GlobalExceptionHandler.AppleVerificationException();
+            }
+
+            String aud = (String) claims.get("aud");
+            if (!clientSecretProvider.getClientId().equals(aud)) {
+                throw new com.YOGIITSU.config.handler.GlobalExceptionHandler.AppleTokenInvalidException();
+            }
+
+            Number exp = (Number) claims.get("exp");
+            if (exp == null || System.currentTimeMillis() >= exp.longValue() * 1000L) {
+                throw new com.YOGIITSU.config.handler.GlobalExceptionHandler.AppleTokenInvalidException();
+            }
 
             String sub = (String) claims.get("sub");
             String email = (String) claims.get("email");

--- a/src/main/java/com/YOGIITSU/service/AppleAuthService.java
+++ b/src/main/java/com/YOGIITSU/service/AppleAuthService.java
@@ -57,6 +57,10 @@ public class AppleAuthService {
                 Map.class
             );
 
+            if (response.getBody() == null || response.getBody().get("id_token") == null) {
+                throw new IllegalArgumentException("Apple 토큰 응답이 비어있음");
+            }
+
             String idToken = (String) response.getBody().get("id_token");
             Map<String, Object> claims = AppleJwtUtil.verifyAndGetClaims(idToken);
 

--- a/src/main/java/com/YOGIITSU/util/AppleJwtUtil.java
+++ b/src/main/java/com/YOGIITSU/util/AppleJwtUtil.java
@@ -1,0 +1,56 @@
+package com.YOGIITSU.util;
+
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.ApplePublicKeyNotFoundException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.AppleTokenInvalidException;
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.AppleVerificationException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.SignedJWT;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Map;
+
+public class AppleJwtUtil {
+
+    private static final String APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys";
+
+    public static Map<String, Object> verifyAndGetClaims(String identityToken) {
+        try {
+            // 1. 토큰 파싱
+            SignedJWT signedJWT = SignedJWT.parse(identityToken);
+            String kid = signedJWT.getHeader().getKeyID();
+
+            // 2. 애플 공개키 세트 가져오기
+            JWKSet jwkSet;
+            try (InputStream is = new URL(APPLE_KEYS_URL).openStream()) {
+                jwkSet = JWKSet.load(is);
+            }
+
+            // 3. kid에 맞는 공개키 찾기
+            JWK jwk = jwkSet.getKeyByKeyId(kid);
+            if (jwk == null) {
+                throw new ApplePublicKeyNotFoundException();
+            }
+
+            RSAKey rsaKey = (RSAKey) jwk;
+            RSAPublicKey publicKey = rsaKey.toRSAPublicKey();
+
+            // 4. 서명 검증
+            JWSVerifier verifier = new RSASSAVerifier(publicKey);
+            if (!signedJWT.verify(verifier)) {
+                throw new AppleTokenInvalidException();
+            }
+
+            // 5. payload 반환
+            return signedJWT.getJWTClaimsSet().getClaims();
+        } catch (ApplePublicKeyNotFoundException | AppleTokenInvalidException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AppleVerificationException();
+        }
+    }
+}

--- a/src/main/java/com/YOGIITSU/util/ClientSecretProvider.java
+++ b/src/main/java/com/YOGIITSU/util/ClientSecretProvider.java
@@ -2,12 +2,11 @@ package com.YOGIITSU.util;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -28,39 +27,49 @@ public class ClientSecretProvider {
     @Value("${apple.client-id}")
     private String clientId;
 
-    @Value("${apple.key-path}")
-    private String keyPath;
+    @Value("${apple.private-key-path}")
+    private String privateKeyPath;
 
     public String createClientSecret() {
         try {
-            PrivateKey privateKey = leadPrivateKey(keyPath);
-
+            PrivateKey privateKey = loadPrivateKey(privateKeyPath);
             Instant now = Instant.now();
 
             return Jwts.builder()
                 .setHeaderParam("kid", keyId)
-                .setIssuer(teamId)
-                .setAudience("https://appleid.apple.com")
-                .setSubject(clientId)
+                .setIssuer(teamId)  // iss: Apple Developer Team ID
+                .setAudience("https://appleid.apple.com")  // aud: 고정
+                .setSubject(clientId)  // sub: Service ID
                 .setIssuedAt(Date.from(now))
-                .setExpiration(Date.from(now.plusSeconds(1800)))
+                .setExpiration(Date.from(now.plusSeconds(1800)))  // 30분 유효 (Apple은 최대 6개월 허용)
                 .signWith(privateKey, SignatureAlgorithm.ES256)
                 .compact();
         } catch (Exception e) {
-            throw new RuntimeException("애플 client_sercret 생성 실패", e);
+            throw new RuntimeException("Apple client_secret 생성 실패", e);
         }
     }
 
-    private PrivateKey leadPrivateKey(String keyPath) throws Exception {
-        String key = new String(Files.readAllBytes(Paths.get(keyPath)))
-            .replace("-----BEGIN PRIVATE KEY-----", "")
-            .replace("-----END PRIVATE KEY-----", "")
-            .replace("\\s", "");
+    private PrivateKey loadPrivateKey(String keyPath) throws Exception {
+        InputStream is;
 
-        byte[] encoded = Base64.getDecoder().decode(key);
-        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
-        KeyFactory keyFactory = KeyFactory.getInstance("EC");
-        return keyFactory.generatePrivate(keySpec);
+        if (!keyPath.startsWith("file:")) {
+            throw new IllegalArgumentException("지원하지 않는 keyPath 형식: " + keyPath);
+        }
+
+        String filePath = keyPath.replace("file:", "");
+        try (FileInputStream fis = new FileInputStream(filePath)) {
+            byte[] keyBytes = fis.readAllBytes();
+
+            String privateKeyPem = new String(keyBytes)
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s+", "");
+
+            byte[] decoded = Base64.getDecoder().decode(privateKeyPem);
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(keySpec);
+        }
     }
 
 }

--- a/src/main/java/com/YOGIITSU/util/ClientSecretProvider.java
+++ b/src/main/java/com/YOGIITSU/util/ClientSecretProvider.java
@@ -30,6 +30,9 @@ public class ClientSecretProvider {
     @Value("${apple.private-key-path}")
     private String privateKeyPath;
 
+    /**
+     * Apple client_secret(JWT) 생성
+     */
     public String createClientSecret() {
         try {
             PrivateKey privateKey = loadPrivateKey(privateKeyPath);
@@ -49,6 +52,9 @@ public class ClientSecretProvider {
         }
     }
 
+    /**
+     * p8 키 파일에서 PrivateKey 로드
+     */
     private PrivateKey loadPrivateKey(String keyPath) throws Exception {
         InputStream is;
 

--- a/src/main/java/com/YOGIITSU/util/ClientSecretProvider.java
+++ b/src/main/java/com/YOGIITSU/util/ClientSecretProvider.java
@@ -1,0 +1,66 @@
+package com.YOGIITSU.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@Getter
+public class ClientSecretProvider {
+
+    @Value("${apple.team-id}")
+    private String teamId;
+
+    @Value("${apple.key-id}")
+    private String keyId;
+
+    @Value("${apple.client-id}")
+    private String clientId;
+
+    @Value("${apple.key-path}")
+    private String keyPath;
+
+    public String createClientSecret() {
+        try {
+            PrivateKey privateKey = leadPrivateKey(keyPath);
+
+            Instant now = Instant.now();
+
+            return Jwts.builder()
+                .setHeaderParam("kid", keyId)
+                .setIssuer(teamId)
+                .setAudience("https://appleid.apple.com")
+                .setSubject(clientId)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plusSeconds(1800)))
+                .signWith(privateKey, SignatureAlgorithm.ES256)
+                .compact();
+        } catch (Exception e) {
+            throw new RuntimeException("애플 client_sercret 생성 실패", e);
+        }
+    }
+
+    private PrivateKey leadPrivateKey(String keyPath) throws Exception {
+        String key = new String(Files.readAllBytes(Paths.get(keyPath)))
+            .replace("-----BEGIN PRIVATE KEY-----", "")
+            .replace("-----END PRIVATE KEY-----", "")
+            .replace("\\s", "");
+
+        byte[] encoded = Base64.getDecoder().decode(key);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
+        KeyFactory keyFactory = KeyFactory.getInstance("EC");
+        return keyFactory.generatePrivate(keySpec);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,12 @@ spring:
         registration:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
+        provider:
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize
+            token-uri: https://appleid.apple.com/auth/token
+            jwk-set-uri: https://appleid.apple.com/auth/keys
+            user-name-attribute: sub
 
   jpa:
     hibernate:
@@ -72,3 +78,9 @@ email:
     - suwon.ac.kr
     - naver.com
     - gmail.com
+
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+  team-id: ${APPLE_TEAM_ID}
+  key-id: ${APPLE_KEY_ID}
+  private-key-path: ${APPLE_PRIVATE_KEY_PATH}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/apple-login` → `develop`

### 변경 사항
- Apple 소셜 로그인 기능 구현
  - Apple identityToken 검증 및 Claims 추출
  - 신규 사용자 회원가입 처리 및 기존 사용자 로그인 처리
  - JWT 토큰 발급 및 응답 반환
- 관련 예외 처리 추가
  - AppleTokenInvalidException
  - ApplePublicKeyNotFoundException
  - AppleVerificationException

### 테스트 결과
- 로컬 환경에서는 Apple 로그인 테스트가 불가능하여, 프론트엔드 연동 후 검증 및 수정 예정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Apple 소셜 로그인 추가: POST /auth/apple로 로그인 가능, 액세스/리프레시 토큰 발급 및 응답 헤더(Bearer, X-Refresh-Token) 제공.
  - Apple 아이덴티티 토큰 검증 및 클라이언트 시크릿 생성 도입.

- Chores
  - Apple 관련 설정 항목(application.yml, 환경변수) 추가.
  - JWT 라이브러리 의존성 추가.
  - 로컬/개발용 애플리케이션 설정 파일 무시 규칙(.gitignore) 추가.

- Fixes
  - CORS 노출 헤더에 X-Refresh-Token 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->