### PR TITLE
feat: 마이페이지 프로필 API 구현

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/MypageProfileController.java
+++ b/src/main/java/com/YOGIITSU/controller/MypageProfileController.java
@@ -1,0 +1,30 @@
+package com.YOGIITSU.controller;
+
+import com.YOGIITSU.dto.ResponseDto.MypageProfileResponseDto;
+import com.YOGIITSU.jwt.CustomUserDetails;
+import com.YOGIITSU.service.MypageProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage")
+public class MypageProfileController {
+
+    private final MypageProfileService mypageProfileService;
+
+    @Operation(summary = "마이페이지 프로필 조회", description = "로그인된 사용자의 프로필 정보를 조회합니다.")
+    @GetMapping("/profile")
+    public ResponseEntity<MypageProfileResponseDto> getMyProfile(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+            mypageProfileService.getProfile(userDetails.getId())
+        );
+    }
+}

--- a/src/main/java/com/YOGIITSU/controller/MypageProfileController.java
+++ b/src/main/java/com/YOGIITSU/controller/MypageProfileController.java
@@ -11,6 +11,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * MypageProfileController
+ * - 마이페이지 프로필 관련 API 제공
+ * - 로그인된 사용자의 프로필 조회 기능 포함
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/mypage")
@@ -18,6 +23,12 @@ public class MypageProfileController {
 
     private final MypageProfileService mypageProfileService;
 
+    /**
+     * 마이페이지 프로필 조회 API
+     * - 인증된 사용자의 프로필 정보를 조회
+     * - 사용자 ID 기반으로 서비스 호출
+     * - 응답 body에 MypageProfileResponseDto 반환
+     */
     @Operation(summary = "마이페이지 프로필 조회", description = "로그인된 사용자의 프로필 정보를 조회합니다.")
     @GetMapping("/profile")
     public ResponseEntity<MypageProfileResponseDto> getMyProfile(

--- a/src/main/java/com/YOGIITSU/controller/MypageProfileController.java
+++ b/src/main/java/com/YOGIITSU/controller/MypageProfileController.java
@@ -4,6 +4,7 @@ import com.YOGIITSU.dto.ResponseDto.MypageProfileResponseDto;
 import com.YOGIITSU.jwt.CustomUserDetails;
 import com.YOGIITSU.service.MypageProfileService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  * - 마이페이지 프로필 관련 API 제공
  * - 로그인된 사용자의 프로필 조회 기능 포함
  */
+@Tag(name = "마이페이지 프로필 API", description = "로그인한 사용자의 프로필 정보를 조회하는 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/mypage")

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/MypageProfileResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/MypageProfileResponseDto.java
@@ -1,0 +1,16 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class MypageProfileResponseDto {
+
+    private String userName;  // 사용자 이름
+    private String email;  // 이메일
+    private String memberId;  // 로그인 ID
+    private String provider;  // 가입 경로 (local, google, kakao, apple 등)
+}

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/MypageProfileResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/MypageProfileResponseDto.java
@@ -12,5 +12,4 @@ public class MypageProfileResponseDto {
     private String userName;  // 사용자 이름
     private String email;  // 이메일
     private String memberId;  // 로그인 ID
-    private String provider;  // 가입 경로 (local, google, kakao, apple 등)
 }

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/MypageProfileResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/MypageProfileResponseDto.java
@@ -9,7 +9,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class MypageProfileResponseDto {
 
+    private String memberId;  // 로그인 ID
     private String userName;  // 사용자 이름
     private String email;  // 이메일
-    private String memberId;  // 로그인 ID
 }

--- a/src/main/java/com/YOGIITSU/entity/Member.java
+++ b/src/main/java/com/YOGIITSU/entity/Member.java
@@ -38,6 +38,9 @@ public class Member implements UserDetails {
     @Column(name = "user_name", length = 50)
     private String userName; // 사용자 이름
 
+    @Column(name = "profile_image_url", length = 255)
+    private String profileImageUrl;
+
     @Column(name = "role", length = 50)
     private String role; // 유저 or 관리자
 

--- a/src/main/java/com/YOGIITSU/entity/Member.java
+++ b/src/main/java/com/YOGIITSU/entity/Member.java
@@ -38,9 +38,6 @@ public class Member implements UserDetails {
     @Column(name = "user_name", length = 50)
     private String userName; // 사용자 이름
 
-    @Column(name = "profile_image_url", length = 255)
-    private String profileImageUrl;
-
     @Column(name = "role", length = 50)
     private String role; // 유저 or 관리자
 

--- a/src/main/java/com/YOGIITSU/service/MypageProfileService.java
+++ b/src/main/java/com/YOGIITSU/service/MypageProfileService.java
@@ -8,12 +8,26 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * MypageProfileService
+ * - 마이페이지 프로필 조회 비즈니스 로직 처리
+ * - DB에서 사용자 정보를 조회하여 DTO로 반환
+ */
 @Service
 @RequiredArgsConstructor
 public class MypageProfileService {
 
     private final MemberRepository memberRepository;
 
+    /**
+     * 마이페이지 프로필 조회
+     * - memberId 기준으로 사용자 엔티티 조회
+     * - 존재하지 않는 경우 MemberNotFoundException 발생
+     * - 조회한 엔티티를 MypageProfileResponseDto로 변환 후 반환
+     *
+     * @param memberId 사용자 고유 ID (PK)
+     * @return MypageProfileResponseDto 사용자 프로필 응답 DTO
+     */
     @Transactional(readOnly = true)
     public MypageProfileResponseDto getProfile(Long memberId) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/com/YOGIITSU/service/MypageProfileService.java
+++ b/src/main/java/com/YOGIITSU/service/MypageProfileService.java
@@ -1,0 +1,28 @@
+package com.YOGIITSU.service;
+
+import com.YOGIITSU.config.handler.GlobalExceptionHandler.MemberNotFoundException;
+import com.YOGIITSU.dto.ResponseDto.MypageProfileResponseDto;
+import com.YOGIITSU.entity.Member;
+import com.YOGIITSU.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MypageProfileService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MypageProfileResponseDto getProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(MemberNotFoundException::new);
+
+        return MypageProfileResponseDto.builder()
+            .memberId(member.getMemberId())
+            .userName(member.getUserName())
+            .email(member.getEmail())
+            .build();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/mypage-profile` → `develop`

### 변경 사항
- 마이페이지 프로필 조회 API 추가  
- Controller, Service, DTO 작성  
- Swagger 문서화 적용  

### 테스트 결과
- 로컬 환경에서 Swagger UI를 통해 프로필 조회 API 호출 성공  
- 로그인 사용자 인증 후 프로필 정보(`memberId`, `userName`, `email`) 정상 반환 확인  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 마이페이지 프로필 조회 API 추가: 로그인한 사용자의 프로필 정보를 반환합니다(회원 ID, 사용자명, 이메일). 경로: /mypage/profile
- Documentation
  - 새 프로필 조회 API에 대한 Swagger 문서 추가로 엔드포인트 설명과 응답 스키마 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->