### PR TITLE
feat: 비회원도 건물 조회 및 검색 기능 사용 가능하도록 개선

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/BuildingController.java
+++ b/src/main/java/com/YOGIITSU/controller/BuildingController.java
@@ -32,7 +32,8 @@ public class BuildingController {
 		summary = "건물 상세 조회",
 		description = """
 			건물 ID를 기반으로 상세 정보를 조회합니다. <br>
-			각 건물에 대한 사용자의 즐겨찾기 여부를 포함한 결과를 반환합니다. <br><br>
+			로그인한 사용자의 경우 즐겨찾기 여부를 포함한 결과를 반환합니다. <br>
+			비회원의 경우 기본 건물 정보만 반환됩니다. <br><br>
 
 			사용 가능한 건물 ID 목록:<br>
 			1: 인문사회융합대학<br>
@@ -68,28 +69,31 @@ public class BuildingController {
 				"예시:<br>9 → 지능형SW융합대학<br>13 → 경영공학대학",
 			example = "9"
 		)
-
 		@PathVariable Long id,
-
 		@Parameter(hidden = true)
 		HttpServletRequest request
 	) {
-		// 1. 로그인한 사용자인 경우 MemberId 추출
-		Long memberId = jwtUtil.extractMemberId(request);
+		// 1. 토큰이 있으면 MemberId 추출, 없으면 null
+		Long memberId = jwtUtil.extractMemberIdSafely(request);
 
-		// 2. 서비스 호출 → 즐겨찾기 여부까지 포함해서 반환
+		// 2. 서비스 호출 → 토큰이 있으면 즐겨찾기 여부까지 포함해서 반환
 		return buildingService.getBuildingDetail(id, memberId);
 	}
 
 	@Operation(
 		summary = "전체 건물 목록 조회",
-		description = "앱의 전체 단과대(건물) 스크롤 화면에 사용될 건물 목록 전체를 조회합니다."
+		description = """
+			앱의 전체 단과대(건물) 스크롤 화면에 사용될 건물 목록 전체를 조회합니다.
+			로그인한 사용자의 경우 즐겨찾기 여부를 포함한 결과를 반환합니다.
+			비회원의 경우 기본 건물 정보만 반환됩니다.
+		"""
 	)
 	@GetMapping
 	public List<BuildingListResponseDto> getAllBuildings(
 		@Parameter(hidden = true) HttpServletRequest request
 	) {
-		Long memberId = jwtUtil.extractMemberId(request);
+		// 토큰이 있으면 MemberId 추출, 없으면 null
+		Long memberId = jwtUtil.extractMemberIdSafely(request);
 		return buildingService.getAllBuildings(memberId);
 	}
 }

--- a/src/main/java/com/YOGIITSU/controller/SearchSuggestionController.java
+++ b/src/main/java/com/YOGIITSU/controller/SearchSuggestionController.java
@@ -1,10 +1,8 @@
 package com.YOGIITSU.controller;
 
-import com.YOGIITSU.exception.auth.InvalidTokenException;
-import com.YOGIITSU.exception.auth.MissingTokenException;
 import com.YOGIITSU.dto.ResponseDto.SearchSuggestionResponseDto;
-import com.YOGIITSU.jwt.JwtTokenProvider;
 import com.YOGIITSU.service.SearchSuggestionService;
+import com.YOGIITSU.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,7 +21,7 @@ import java.util.List;
 public class SearchSuggestionController {
 
 	private final SearchSuggestionService searchSuggestionService;
-	private final JwtTokenProvider jwtTokenProvider;
+	private final JwtUtil jwtUtil;
 
 	/**
 	 * 자동완성 검색어 추천 API
@@ -33,8 +31,11 @@ public class SearchSuggestionController {
 	 */
 	@Operation(
 		summary = "검색어 자동완성 추천",
-		description = "사용자가 입력한 query 값을 기준으로 자동완성 검색어 리스트를 반환합니다. (JWT 인증 필요)\n" +
-			"※ 즐겨찾기한 검색어가 있을 경우, 우선적으로 상단에 배치되어 반환됩니다."
+		description = """
+			사용자가 입력한 query 값을 기준으로 자동완성 검색어 리스트를 반환합니다. <br>
+			로그인한 사용자의 경우 즐겨찾기한 검색어가 우선적으로 상단에 배치됩니다. <br>
+			비회원의 경우 일반 검색 결과만 반환됩니다.
+		"""
 	)
 	@GetMapping("/suggestions")
 	public ResponseEntity<List<SearchSuggestionResponseDto>> getSearchSuggestions(
@@ -42,24 +43,16 @@ public class SearchSuggestionController {
 		@RequestParam(required = false) String query,
 		HttpServletRequest httpRequest) {
 
-		// 1. JWT 토큰 검증
-		String accessToken = jwtTokenProvider.resolveToken(httpRequest);
-		if (accessToken == null) {
-			throw new MissingTokenException();
-		}
-		if (!jwtTokenProvider.validateToken(accessToken)) {
-			throw new InvalidTokenException();
-		}
-
-		// 2. 검색어가 없거나 공백만 있는 경우 빈 리스트 반환
+		// 1. 검색어가 없거나 공백만 있는 경우 빈 리스트 반환
 		if (query == null || query.isBlank()) {
 			return ResponseEntity.ok(Collections.emptyList());
 		}
 
-		// 3. 사용자 ID 추출
-		String memberId = jwtTokenProvider.getAuthentication(accessToken).getName();
+		// 2. 토큰이 있으면 MemberId 추출, 없으면 null
+		Long memberIdLong = jwtUtil.extractMemberIdSafely(httpRequest);
+		String memberId = memberIdLong != null ? memberIdLong.toString() : null;
 
-		// 4. 자동완성 검색어 반환
+		// 3. 자동완성 검색어 반환
 		return ResponseEntity.ok(searchSuggestionService.getSearchSuggestions(query, memberId));
 	}
 }

--- a/src/main/java/com/YOGIITSU/controller/SearchSuggestionController.java
+++ b/src/main/java/com/YOGIITSU/controller/SearchSuggestionController.java
@@ -49,8 +49,7 @@ public class SearchSuggestionController {
 		}
 
 		// 2. 토큰이 있으면 MemberId 추출, 없으면 null
-		Long memberIdLong = jwtUtil.extractMemberIdSafely(httpRequest);
-		String memberId = memberIdLong != null ? memberIdLong.toString() : null;
+		String memberId = jwtUtil.extractMemberIdStringSafely(httpRequest);
 
 		// 3. 자동완성 검색어 반환
 		return ResponseEntity.ok(searchSuggestionService.getSearchSuggestions(query, memberId));

--- a/src/main/java/com/YOGIITSU/service/BuildingService.java
+++ b/src/main/java/com/YOGIITSU/service/BuildingService.java
@@ -7,10 +7,8 @@ import com.YOGIITSU.entity.Building;
 import com.YOGIITSU.exception.building.BuildingNotFoundException;
 import com.YOGIITSU.repository.BuildingRepository;
 import com.YOGIITSU.repository.FavoriteRepository;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,15 +26,15 @@ public class BuildingService {
 	 * 건물 상세 정보를 조회하는 메서드
 	 *
 	 * @param buildingId 조회할 건물의 ID
-	 * @param memberId   조회하는 사용자의 ID (즐겨찾기 여부 확인용)
+	 * @param memberId   조회하는 사용자의 ID (즐겨찾기 여부 확인용, null이면 비회원)
 	 * @return 건물의 상세 정보를 담은 BuildingDetailResponseDto
 	 */
 	@Transactional(readOnly = true)
 	public BuildingDetailResponseDto getBuildingDetail(Long buildingId, Long memberId) {
 		Building building = findBuildingById(buildingId);
 
-		//즐겨찾기 여부 조회
-		boolean isFavorite = favoriteRepository.existsByMemberIdAndBuildingId(memberId, buildingId);
+		// 즐겨찾기 여부 조회 (memberId가 null이면 비회원이므로 false)
+		boolean isFavorite = memberId != null && favoriteRepository.existsByMemberIdAndBuildingId(memberId, buildingId);
 
 		return buildingConverter.convertToBuildingDetailResponseDto(building, isFavorite);
 	}
@@ -56,14 +54,17 @@ public class BuildingService {
 	/**
 	 * 전체 건물 목록을 조회하는 메서드 (즐겨찾기 여부 포함)
 	 *
-	 * @param memberId 현재 로그인한 사용자의 ID
+	 * @param memberId 현재 로그인한 사용자의 ID (null이면 비회원)
 	 * @return 건물 목록 정보를 담은 List<BuildingListResponseDto>
 	 */
 	@Transactional(readOnly = true)
 	public List<BuildingListResponseDto> getAllBuildings(Long memberId) {
 		List<BuildingListResponseDto> buildings = buildingRepository.findAllSimpleList();
 
-		Set<Long> favoriteBuildingIds = favoriteRepository.findBuildingIdsByMemberId(memberId);
+		// memberId가 null이면 비회원이므로 빈 Set 사용
+		Set<Long> favoriteBuildingIds = memberId != null ? 
+			favoriteRepository.findBuildingIdsByMemberId(memberId) : 
+			Set.of();
 
 		return buildingConverter.convertToBuildingListResponseDto(buildings, favoriteBuildingIds);
 	}

--- a/src/main/java/com/YOGIITSU/service/SearchSuggestionService.java
+++ b/src/main/java/com/YOGIITSU/service/SearchSuggestionService.java
@@ -28,16 +28,17 @@ public class SearchSuggestionService {
 	private final MemberRepository memberRepository;
 
 	public List<SearchSuggestionResponseDto> getSearchSuggestions(String query, String memberId) {
-		// 1. 사용자 정보 조회
-		Member member = findMemberById(memberId);
+		// 1. memberId가 null이면 비회원이므로 즐겨찾기 건물은 빈 리스트
+		List<Building> bookmarkedBuildings = new ArrayList<>();
+		if (memberId != null) {
+			Member member = findMemberById(memberId);
+			bookmarkedBuildings = findBookmarkedBuildings(member, query);
+		}
 
-		// 2. 사용자의 즐겨찾기된 건물 목록 가져오기 (즐겨찾기된 건물 중 검색어 포함된 것)
-		List<Building> bookmarkedBuildings = findBookmarkedBuildings(member, query);
-
-		// 3. DB에서 검색어가 포함된 건물 리스트 가져오기
+		// 2. DB에서 검색어가 포함된 건물 리스트 가져오기
 		List<Building> searchResults = findBuildingsWithAliases(query);
 
-		// 4. 즐겨찾기된 건물 리스트 + 일반 검색 결과 리스트 합치기
+		// 3. 즐겨찾기된 건물 리스트 + 일반 검색 결과 리스트 합치기
 		return mergeResults(bookmarkedBuildings, searchResults);
 	}
 

--- a/src/main/java/com/YOGIITSU/util/JwtUtil.java
+++ b/src/main/java/com/YOGIITSU/util/JwtUtil.java
@@ -66,4 +66,33 @@ public class JwtUtil {
 			return null;
 		}
 	}
+
+	/**
+	 * JWT 토큰에서 사용자 ID를 추출하는 메서드 (String 타입, 토큰이 없어도 예외 발생하지 않음)
+	 *
+	 * @param request HTTP 요청 객체
+	 * @return 사용자 ID(String), 토큰이 없거나 유효하지 않으면 null
+	 */
+	public String extractMemberIdStringSafely(HttpServletRequest request) {
+		try {
+			// 1. 요청에서 JWT 토큰 추출
+			String accessToken = jwtTokenProvider.resolveToken(request);
+
+			// 2. 토큰이 없으면 null 반환
+			if (accessToken == null) {
+				return null;
+			}
+
+			// 3. 토큰이 유효한지 확인, 유효하지 않으면 null 반환
+			if (!jwtTokenProvider.validateToken(accessToken)) {
+				return null;
+			}
+
+			// 4. 유효한 토큰이라면 사용자 ID 추출
+			return jwtTokenProvider.getAuthentication(accessToken).getName();
+		} catch (Exception e) {
+			// 토큰 관련 예외가 발생하면 null 반환
+			return null;
+		}
+	}
 }

--- a/src/main/java/com/YOGIITSU/util/JwtUtil.java
+++ b/src/main/java/com/YOGIITSU/util/JwtUtil.java
@@ -37,4 +37,33 @@ public class JwtUtil {
 		// 4. 유효한 토큰이라면 사용자 ID 추출
 		return jwtTokenProvider.getMemberId(accessToken);
 	}
+
+	/**
+	 * JWT 토큰에서 사용자 ID를 추출하는 메서드 (토큰이 없어도 예외 발생하지 않음)
+	 *
+	 * @param request HTTP 요청 객체
+	 * @return 사용자 ID(Long), 토큰이 없거나 유효하지 않으면 null
+	 */
+	public Long extractMemberIdSafely(HttpServletRequest request) {
+		try {
+			// 1. 요청에서 JWT 토큰 추출
+			String accessToken = jwtTokenProvider.resolveToken(request);
+
+			// 2. 토큰이 없으면 null 반환
+			if (accessToken == null) {
+				return null;
+			}
+
+			// 3. 토큰이 유효한지 확인, 유효하지 않으면 null 반환
+			if (!jwtTokenProvider.validateToken(accessToken)) {
+				return null;
+			}
+
+			// 4. 유효한 토큰이라면 사용자 ID 추출
+			return jwtTokenProvider.getMemberId(accessToken);
+		} catch (Exception e) {
+			// 토큰 관련 예외가 발생하면 null 반환
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`refactor/token-cleanup` → `develop`

### 변경 사항

앱스토어 심사 통과를 위해 비회원도 기본 기능을 사용할 수 있도록 건물 조회 및 검색 자동완성 API를 개선했습니다.

### **🔧 주요 변경 내용**

- **JwtUtil**: extractMemberIdSafely() 메서드 추가 (토큰 없어도 예외 발생하지 않음)
- **BuildingController**: 토큰 있으면 즐겨찾기 여부 포함, 없으면 기본 정보만 반환
- **BuildingService**: memberId null 처리 로직 추가
- **SearchSuggestionController**: 토큰 있으면 즐겨찾기 우선 표시, 없으면 일반 검색 결과
- **SearchSuggestionService**: memberId null 처리 로직 추가

### 

### 테스트 결과

- [x]  비회원으로 건물 상세 조회 테스트
- [x]  비회원으로 건물 목록 조회 테스트
- [x]  비회원으로 검색 자동완성 테스트
- [x]  회원으로 기존 기능 정상 동작 확인