### PR TITLE
refactor: 아이디 찾기 API 예외처리 패턴 통일 및 유효성 검사 강화

### DIFF
--- a/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/YOGIITSU/config/handler/GlobalExceptionHandler.java
@@ -32,6 +32,7 @@ import org.springframework.security.authentication.AuthenticationServiceExceptio
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.mail.MailException;
 
 
@@ -91,7 +92,8 @@ public class GlobalExceptionHandler {
             PasswordMismatchException.class,
             PasswordNotEqualsException.class,
             SamePasswordException.class,
-            SameEmailException.class
+            SameEmailException.class,
+            EmailNotRegisteredException.class
     })
     public ResponseEntity<ErrorResponse> handleUserException(BaseException e) {
         log.warn("User exception occurred: {}", e.getMessage(), e);
@@ -150,6 +152,16 @@ public class GlobalExceptionHandler {
         log.warn("Entity not found exception occurred: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ErrorResponse.of(ErrorCode.MEMBER_NOT_FOUND, null));
+    }
+
+    /**
+     * JSON 파싱 예외 처리
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("JSON parsing exception occurred: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(ErrorCode.VALIDATION_ERROR, "요청 형식이 올바르지 않습니다. JSON 형식을 확인해주세요."));
     }
 
     /**

--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.YOGIITSU.controller;
 
 import com.YOGIITSU.exception.auth.InvalidTokenException;
 import com.YOGIITSU.exception.auth.MissingTokenException;
+import com.YOGIITSU.exception.user.EmailNotRegisteredException;
 import com.YOGIITSU.dto.RequestDto.ChangePasswordRequestDto;
 import com.YOGIITSU.dto.RequestDto.MemberLoginRequestDto;
 import com.YOGIITSU.dto.RequestDto.FindMemberIdRequestDto;
@@ -12,10 +13,10 @@ import com.YOGIITSU.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,7 +33,6 @@ public class MemberController {
 	private final MemberService memberService;
 	private final JwtTokenProvider jwtTokenProvider;
 
-	private static final String NO_EMAIL_FOUND = "가입 이력이 없는 이메일입니다.";
 	private static final String EMAIL_MATCH_FOUND = "이메일 정보와 일치하는 아이디가 있습니다.";
 	private static final String MEMBER_DELETION_SUCCESS = "님의 회원 탈퇴가 완료되었습니다.";
 
@@ -62,18 +62,20 @@ public class MemberController {
 	@Operation(summary = "아이디 찾기", description = "이메일을 기반으로 등록된 아이디를 조회합니다.")
 	@PostMapping("/find-id")
 	public ResponseEntity<FindMemberIdResponseDto> findId(
-		@RequestBody FindMemberIdRequestDto request) {
+		@RequestBody @Valid FindMemberIdRequestDto request) {
 		String email = request.getEmail();
 		String memberId = memberService.findIdByEmail(email);
 
+		if (memberId == null) {
+			throw new EmailNotRegisteredException();
+		}
+
 		FindMemberIdResponseDto response = FindMemberIdResponseDto.builder()
-			.status(memberId != null ? "success" : "error")
+			.message(EMAIL_MATCH_FOUND)
 			.id(memberId)
-			.message(memberId == null ? NO_EMAIL_FOUND : EMAIL_MATCH_FOUND)
 			.build();
 
-		return memberId == null ? ResponseEntity.status(HttpStatus.NOT_FOUND).body(response)
-			: ResponseEntity.ok(response);
+		return ResponseEntity.ok(response);
 	}
 
 	/**

--- a/src/main/java/com/YOGIITSU/dto/RequestDto/FindMemberIdRequestDto.java
+++ b/src/main/java/com/YOGIITSU/dto/RequestDto/FindMemberIdRequestDto.java
@@ -1,5 +1,7 @@
 package com.YOGIITSU.dto.RequestDto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +13,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FindMemberIdRequestDto {
 
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
 	private String email;
 
 }

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/FindMemberIdResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/FindMemberIdResponseDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @Builder
 public class FindMemberIdResponseDto {
 
-	private String status;
 	private String id;
 	private String message;
 

--- a/src/main/java/com/YOGIITSU/exception/ErrorCode.java
+++ b/src/main/java/com/YOGIITSU/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 	PASSWORD_NOT_EQUALS("USER_004", "새 비밀번호와 확인 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 	SAME_PASSWORD("USER_005", "기존 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
 	SAME_EMAIL("USER_006", "기존 이메일과 동일한 이메일로는 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
+	EMAIL_NOT_REGISTERED("USER_007", "가입 이력이 없는 이메일입니다.", HttpStatus.NOT_FOUND),
 
 	// 리소스 관련 (3000번대)
 	BUILDING_NOT_FOUND("RESOURCE_001", "존재하지 않는 건물입니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/YOGIITSU/exception/user/EmailNotRegisteredException.java
+++ b/src/main/java/com/YOGIITSU/exception/user/EmailNotRegisteredException.java
@@ -1,0 +1,23 @@
+package com.YOGIITSU.exception.user;
+
+import com.YOGIITSU.exception.ErrorCode;
+
+/**
+ * 가입 이력이 없는 이메일로 아이디 찾기를 시도할 때 발생하는 예외
+ */
+public class EmailNotRegisteredException extends UserException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public EmailNotRegisteredException() {
+        super(ErrorCode.EMAIL_NOT_REGISTERED);
+    }
+    
+    public EmailNotRegisteredException(String detailMessage) {
+        super(ErrorCode.EMAIL_NOT_REGISTERED, detailMessage);
+    }
+    
+    public EmailNotRegisteredException(String detailMessage, Throwable cause) {
+        super(ErrorCode.EMAIL_NOT_REGISTERED, detailMessage, cause);
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/exception-handling` → `develop`

### 변경 사항
#### ✨ 기능 추가

- **아이디 찾기 전용 예외 처리 시스템 구축**
    - ErrorCode.EMAIL_NOT_REGISTERED (USER_007) 추가
    - EmailNotRegisteredException 클래스 생성
    - GlobalExceptionHandler에 새 예외 처리 로직 추가
- **입력값 검증 강화**
    - FindMemberIdRequestDto에 @NotBlank, @Email 유효성 검사 어노테이션 추가
    - @Valid 어노테이션으로 자동 검증 활성화

#### 🔧 코드 리팩토링

- **예외처리 패턴 통일**
    - 기존: 직접 ResponseEntity.status(HttpStatus.NOT_FOUND) 처리
    - 개선: 예외 기반 처리로 변경하여 GlobalExceptionHandler에서 통합 관리
- **응답 구조 간소화**
    - FindMemberIdResponseDto에서 불필요한 status 필드 제거
    - 다른 API들과 일관된 응답 구조로 통일
 
### 테스트 결과
#### ✅ 단위 테스트
- [x]  유효한 이메일로 아이디 찾기 성공 케이스
- [x]  존재하지 않는 이메일로 요청 시 EmailNotRegisteredException 발생
- [x]  잘못된 이메일 형식으로 요청 시 MethodArgumentNotValidException 발생
- [x]  빈 이메일로 요청 시 MethodArgumentNotValidException 발생

#### ✅ 통합 테스트
- [x]  아이디 찾기 API 엔드포인트 정상 동작 확인
- [x]  GlobalExceptionHandler를 통한 일관된 에러 응답 형식 확인
- [x]  다른 API들과 동일한 예외처리 패턴 적용 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 잘못된 JSON 요청 본문에 대해 400 응답과 명확한 오류 메시지를 제공합니다.
  - 아이디 찾기 요청에 이메일 유효성 검사(필수, 형식)를 추가했습니다.
  - 미등록 이메일 사용 시 일관된 오류 응답을 제공합니다.

- Refactor
  - 아이디 찾기 응답을 단순화했습니다: status 필드를 제거하고, 항상 200 OK와 고정 메시지 및 찾은 아이디를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->