### PR TITLE
feat: Jacoco 기반 코드 커버리지 리포트 자동화 구성

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,59 @@
+name: Code Coverage Report
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  push:
+    branches: [ main, develop ]
+
+jobs:
+  test-and-coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    
+    steps:
+    - name: 코드 체크아웃
+      uses: actions/checkout@v4
+      
+    - name: Java 21 설정
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        
+    - name: Gradle 캐시 설정
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+          
+    - name: 테스트 실행 및 커버리지 리포트 생성
+      run: ./gradlew clean test jacocoTestReport
+      
+    - name: 커버리지 리포트 업로드
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: coverage-report
+        path: build/reports/jacoco/
+        retention-days: 30
+        
+    - name: PR에 커버리지 코멘트 등록
+      if: github.event_name == 'pull_request'
+      uses: madrapps/jacoco-report@v1.2
+      with:
+        title: 테스트 커버리지 리포트
+        paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
+        min-coverage-overall: 50
+        min-coverage-changed-files: 50
+        fail-on-coverage-drop: false
+        show-missing: true
+        show-line-coverage: true
+        show-branch-coverage: true

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.5'
+	id 'jacoco'
 }
 
 group = 'com.YOGIITSU'
@@ -67,4 +68,35 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		xml.outputLocation = layout.buildDirectory.file('reports/jacoco/test/jacocoTestReport.xml')
+		csv.required = false
+		html.required = true
+		html.outputLocation = layout.buildDirectory.dir('reports/jacoco')
+	}
+
+	classDirectories.setFrom(files(classDirectories.files.collect {
+		fileTree(dir: it, exclude: [
+			'**/entity/**',
+			'**/dto/**',
+			'**/exception/**',
+			'**/enums/**',
+			'**/jwt/**',
+			'**/util/**',
+			'**/converter/**',
+			'**/scheduler/**',
+			'**/config/**',
+			'**/YogiitsuApplication.class'
+		])
+	}))
+}
+
+jacoco {
+	toolVersion = "0.8.13"
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+# Lombok이 생성한 메서드들을 커버리지에서 제외
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION

### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/code-coverage` → `develop`

### 변경 사항
**1. Jacoco 플러그인 설정 (build.gradle)**

- Jacoco 플러그인 추가 및 버전 0.8.13 설정
- HTML/XML 리포트 자동 생성 설정
- Service/Controller 계층만 커버리지 측정하도록 범위 제한
- test → jacocoTestReport 자동 실행 체인 구성

**2. GitHub Actions 워크플로우 (.github/workflows/coverage-report.yml)**

- PR 생성 시 자동 커버리지 코멘트 등록
- Push 시 커버리지 아티팩트 저장
- 최소 커버리지 50% 설정 (전체/변경된 파일)
- Gradle 캐시 최적화로 빌드 속도 향상

**3. Lombok 설정 (lombok.config)**

- Lombok 생성 메서드들을 커버리지에서 제외
- lombok.addLombokGeneratedAnnotation = true 설정
### 테스트 결과

- 커버리지 범위 최적화 확인
포함: Service, Controller 계층만 측정
제외: Entity, DTO, Exception, Enum, JWT, Util, Converter, Scheduler, Config, Application 클래스