### PR TITLE
feat: 신규 서버 배포 CI/CD 워크플로우 추가

### DIFF
--- a/.github/workflows/cicd-new.yml
+++ b/.github/workflows/cicd-new.yml
@@ -1,0 +1,89 @@
+name: cicd-new
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.NEW_EC2_SSH_KEY }}
+
+      - name: Add known_hosts
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            KNOWN_HOSTS_VALUE="${{ secrets.NEW_KNOWNS_HOST }}" 
+          else
+            KNOWN_HOSTS_VALUE="${{ secrets.NEW_DEV_KNOWNS_HOST || secrets.NEW_KNOWNS_HOST }}"
+          fi
+          mkdir -p ~/.ssh
+          echo "$KNOWN_HOSTS_VALUE" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Transfer JAR to EC2
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            EC2_IP="${{ secrets.NEW_EC2_IP }}"
+          else
+            EC2_IP="${{ secrets.NEW_DEV_EC2_IP }}"
+          fi
+          scp build/libs/*.jar ubuntu@$EC2_IP:/home/ubuntu/YOGIITSU/
+
+      - name: Deploy on EC2
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            EC2_IP="${{ secrets.NEW_EC2_IP }}"
+            BRANCH="main"
+          else
+            EC2_IP="${{ secrets.NEW_DEV_EC2_IP }}"
+            BRANCH="develop"
+          fi
+          
+          APPLE_KEY_CONTENT_ONELINE=$(echo "${{ secrets.APPLE_PRIVATE_KEY_CONTENT }}" | tr -d '\n' | tr -d '\r')
+
+          ssh ubuntu@$EC2_IP "
+            export BRANCH='$BRANCH'
+            export DB_URL='${{ secrets.NEW_DB_URL }}'
+            export DB_USERNAME='${{ secrets.DB_USERNAME }}'
+            export DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
+            export GOOGLE_CLIENT_ID='${{ secrets.GOOGLE_CLIENT_ID }}'
+            export MAIL_HOST='${{ secrets.MAIL_HOST }}'
+            export MAIL_PORT='${{ secrets.MAIL_PORT }}'
+            export MAIL_USERNAME='${{ secrets.MAIL_USERNAME }}'
+            export GMAIL_APP_PASSWORD='${{ secrets.GMAIL_APP_PASSWORD }}'
+            export JWT_SECRET='${{ secrets.JWT_SECRET }}'
+            export JWT_ACCESS_EXPIRY='${{ secrets.JWT_ACCESS_EXPIRY }}'
+            export JWT_REFRESH_EXPIRY='${{ secrets.JWT_REFRESH_EXPIRY }}'
+            export SWAGGER_SERVER_URL='${{ secrets.NEW_SWAGGER_SERVER_URL }}'
+            export CORS_ALLOWED_ORIGIN='${{ secrets.NEW_CORS_ALLOWED_ORIGIN }}'
+            export CORS_ALLOWED_ORIGIN_DEV='${{ secrets.NEW_CORS_ALLOWED_ORIGIN_DEV }}'
+            export APPLE_CLIENT_ID='${{ secrets.APPLE_CLIENT_ID }}'
+            export APPLE_TEAM_ID='${{ secrets.APPLE_TEAM_ID }}'
+            export APPLE_KEY_ID='${{ secrets.APPLE_KEY_ID }}'
+            export APPLE_PRIVATE_KEY_CONTENT='$APPLE_KEY_CONTENT_ONELINE'
+          
+            cd /home/ubuntu/YOGIITSU
+            ./deploy.sh
+          "


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [x]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`feature/migrate-cicd-pipeline` → `develop`

### 변경 사항
관련 이슈: #167

기존 서비스의 무중단 도메인/서버 마이그레이션을 위해, 신규 서버로 배포하는 CI/CD 파이프라인을 추가합니다.

- 기존 `cicd.yml` 워크플로우는 수정하지 않고, 신규 서버 배포 전용 `.github/workflows/cicd-new.yml` 파일을 생성했습니다.
- 새 워크플로우(`cicd-new.yml`)는 `NEW_EC2_IP`, `NEW_KNOWN_HOSTS` 등 `NEW_` 접두사가 붙은 GitHub Secrets를 참조하여 신규 서버에 배포를 진행합니다.
- 이 변경으로 `develop` 또는 `main` 브랜치 푸시 시, **기존 서버와 신규 서버에 배포가 동시에 진행**됩니다.
- (참고: 이슈에 언급된 `DB 마이그레이션` 작업은 완료했습니다.)

### 테스트 결과

- **로컬 테스트:** 없음 (CI/CD 파이프라인 변경 사항으로, `develop` 브랜치 트리거를 통해 직접 테스트 필요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 자동화된 CI/CD 배포 파이프라인을 구성했습니다. 개발 및 메인 브랜치로의 푸시 시 자동으로 빌드 및 배포가 진행되도록 설정되어 배포 프로세스의 효율성과 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->