### PR TITLE
fix: 학식 placeholder 데이터 저장 로직 개선으로 불필요한 DB 데이터 제거

### DIFF
--- a/src/main/java/com/YOGIITSU/service/CafeteriaCrawler.java
+++ b/src/main/java/com/YOGIITSU/service/CafeteriaCrawler.java
@@ -234,40 +234,6 @@ public class CafeteriaCrawler {
 			}
 		}
 
-		// --- 추가: 월~금에 비어있는 날을 '(메뉴 준비 중)'으로 보정해서 채워 넣기
-		Set<String> mealTypes = result.stream()
-			.map(ParsedRow::mealType)
-			.map(s -> s == null ? "" : s.trim())
-			.filter(s -> !s.isEmpty())
-			.collect(Collectors.toCollection(LinkedHashSet::new));
-		if (mealTypes.isEmpty()) {
-			mealTypes = Set.of("중식"); // 기본값
-		}
-
-		//월~금에 비어있는 날을 '(메뉴 준비 중)'으로 보정해서 채워 넣기
-		for (String mt : mealTypes) {
-			for (int i = 0; i < 5; i++) {
-				LocalDate d = monday.plusDays(i);
-				boolean exists = result.stream().anyMatch(r ->
-					Objects.equals(r.mealType(), mt) && Objects.equals(r.mealDate(), d)
-				);
-				if (!exists) {
-					String placeholder = "메뉴 준비 중";
-					String hash = DigestUtils.sha1Hex("EMPTY|" + d + "|" + mt);
-					result.add(new ParsedRow(
-						canonicalBuilding(place.building()),
-						canonicalPlace(place.place()),
-						d,
-						mt,
-						null,
-						placeholder,
-						monday,
-						hash
-					));
-				}
-			}
-		}
-
 		return result;
 	}
 

--- a/src/main/java/com/YOGIITSU/service/CafeteriaQueryService.java
+++ b/src/main/java/com/YOGIITSU/service/CafeteriaQueryService.java
@@ -195,6 +195,17 @@ public class CafeteriaQueryService {
 			.findByCafeteriaIdInAndMealDateBetweenOrderByMealDateAscMealTypeAscCornerAsc(
 				cafeteriaIds, monday, friday);
 
+		// placeholder/공백 제거
+		menus = menus.stream()
+			.filter(m -> {
+				String t = Optional.ofNullable(m.getItemsText()).orElse("").trim();
+				if (t.isEmpty()) {
+					return false;
+				}
+				return !Set.of("메뉴 준비 중", "준비중", "준비 중", "-").contains(t);
+			})
+			.toList();
+
 		// 조건 위반하면 바로 예외 -> 글로벌 핸들러가 통일 포맷으로 응답
 		if (menus.isEmpty()) {
 			String detail = "buildingId=" + buildingId + ",week=" + monday + "~" + friday;
@@ -278,8 +289,6 @@ public class CafeteriaQueryService {
 			indexToDate.put(String.valueOf(i), monday.plusDays(i).format(ISO_DATE));
 		}
 
-		String lastUpdatedAt = serverTime;
-
 		return WeeklyCafeteriaResponseDto.builder()
 			.tz(tz)
 			.serverTime(serverTime)
@@ -288,7 +297,7 @@ public class CafeteriaQueryService {
 			.availableIndices(availableIndices)
 			.indexToDate(indexToDate)
 			.menus(menusOut)
-			.lastUpdatedAt(lastUpdatedAt)
+			.lastUpdatedAt(serverTime)
 			.build();
 	}
 }

--- a/src/main/java/com/YOGIITSU/service/CafeteriaSyncService.java
+++ b/src/main/java/com/YOGIITSU/service/CafeteriaSyncService.java
@@ -6,6 +6,7 @@ import com.YOGIITSU.repository.CafeteriaMenuRepository;
 import com.YOGIITSU.repository.CafeteriaRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,20 @@ public class CafeteriaSyncService {
 	private final BuildingLookupService buildingLookup;
 	private final CafeteriaRepository cafeteriaRepo;
 	private final CafeteriaMenuRepository menuRepo;
+
+	// placeholder 문구 목록
+	private static final Set<String> PLACEHOLDER_TOKENS = Set.of("메뉴 준비 중", "준비중", "준비 중", "-");
+
+	private static boolean isPlaceholder(String s) {
+		if (s == null) {
+			return true; // null/blank도 저장 안 함
+		}
+		String t = s.trim();
+		if (t.isEmpty()) {
+			return true;
+		}
+		return PLACEHOLDER_TOKENS.contains(t);
+	}
 
 	@Transactional
 	public void sync(List<CafeteriaCrawler.ParsedRow> rows) {
@@ -42,17 +57,29 @@ public class CafeteriaSyncService {
 			try {
 				Long buildingId = buildingLookup.findBuildingIdByName(r.building())
 					.orElseThrow(() ->
-						new ResourceException(ErrorCode.BUILDING_NOT_FOUND, "building=" + r.building()));
+						new ResourceException(ErrorCode.BUILDING_NOT_FOUND,
+							"building=" + r.building()));
 
-				Cafeteria cafeteria = cafeteriaRepo.findByBuildingIdAndName(buildingId, r.placeName())
+				Cafeteria cafeteria = cafeteriaRepo.findByBuildingIdAndName(buildingId,
+						r.placeName())
 					.orElseGet(() -> cafeteriaRepo.save(
 						Cafeteria.builder().buildingId(buildingId).name(r.placeName()).build()
 					));
 
 				// corner NOT NULL 스키마 대응: null/blank → ""
-				String corner = (r.corner() == null || r.corner().isBlank()) ? "" : r.corner().trim();
+				String corner =
+					(r.corner() == null || r.corner().isBlank()) ? "" : r.corner().trim();
 				String mealType = (r.mealType() == null) ? "" : r.mealType().trim();
 				String itemsText = (r.itemsText() == null) ? "" : r.itemsText();
+
+				// placeholder/공백은 저장하지 않음
+				if (isPlaceholder(itemsText)) {
+					skipped++;
+					log.debug(
+						"[식단] placeholder 스킵: cafeteriaId={}, date={}, mealType='{}', corner='{}'",
+						cafeteria.getId(), r.mealDate(), mealType, corner);
+					continue;
+				}
 
 				// 기존 행 조회 (corner = "" 우선)
 				var existing = menuRepo.findByCafeteriaIdAndMealDateAndMealTypeAndCorner(
@@ -109,6 +136,7 @@ public class CafeteriaSyncService {
 		// 업서트가 끝난 뒤, 최신 주차 이외의 데이터는 모두 정리
 		int deleted = menuRepo.deleteByVersionWeekNot(latestWeek);
 
-		log.info("[식단] 동기화 완료: upsert {}건, 삭제 {}건, 스킵 {}건, 유지 주차={}", upserts, deleted, skipped, latestWeek);
+		log.info("[식단] 동기화 완료: upsert {}건, 삭제 {}건, 스킵 {}건, 유지 주차={}", upserts, deleted, skipped,
+			latestWeek);
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/cafeteria` → `develop`

### 변경 사항
- 문제 원인
-크롤러(CafeteriaCrawler)의 월~금 “빈 날 보정 로직”이 itemsText = "메뉴 준비 중" 형태의 placeholder 데이터를 생성
-동기화(CafeteriaSyncService) 단계에서 corner="" (placeholder) 와 corner="Mom’s Cook" (실제 메뉴)가 서로 다른 키로 저장되어 중복 레코드 발생
-조회(CafeteriaQueryService) 단계에서 placeholder 필터링이 없어 “메뉴 준비 중”이 실제 메뉴와 함께 응답됨

- 개선 내용
-CafeteriaSyncService: "메뉴 준비 중", "준비중", "준비 중", "-" 등 placeholder 문구를 저장하지 않도록 필터링 강화
-CafeteriaQueryService: 조회 시 placeholder 및 공백 데이터 필터링 추가로 불필요한 응답 제거
-CafeteriaCrawler: placeholder 생성 로직 제거 및 HTML 파싱 실패 시 빈 데이터로 종료
-중복 corner("", "Mom’s Cook" 등)로 인한 이중 레코드 저장 방지
-전반적인 로그 메시지 정리 및 데이터 정규화

### 테스트 결과
- 오전 이후(홈페이지 게시 완료 시점) 재실행 시 정상 메뉴만 저장됨
- DB에서 동일 날짜·mealType에 corner="" 와 실제 corner 동시 존재하지 않음
- Swagger 응답 확인 결과 "메뉴 준비 중" 문구 미출력, 실제 메뉴만 노출

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 메뉴 준비가 되지 않은 기간의 플레이스홀더 메뉴 항목 처리 방식을 개선했습니다. 이제 빈 메뉴와 준비 중인 메뉴가 더욱 정확하게 필터링되어 사용자에게 더 깔끔한 메뉴 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->