### PR TITLE
feat: 회원 수 반환 API 구현

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/MemberController.java
+++ b/src/main/java/com/YOGIITSU/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.YOGIITSU.dto.RequestDto.MemberLoginRequestDto;
 import com.YOGIITSU.dto.RequestDto.FindMemberIdRequestDto;
 import com.YOGIITSU.dto.RequestDto.PasswordResetRequestDto;
 import com.YOGIITSU.dto.ResponseDto.FindMemberIdResponseDto;
+import com.YOGIITSU.dto.ResponseDto.MemberCountResponseDto;
 import com.YOGIITSU.jwt.JwtTokenProvider;
 import com.YOGIITSU.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -154,5 +155,18 @@ public class MemberController {
 		memberService.resetPasswordAfterEmailVerification(requestDto);
 
 		return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
+	}
+
+	/**
+	 * 전체 회원 수 조회 API (web)
+	 *
+	 * @return 전체 회원 수
+	 */
+	@Operation(summary = "전체 회원 수 조회", description = "현재 가입된 전체 회원 수를 조회합니다.")
+	@CrossOrigin(origins = {"https://web.yogiitsu.app", "http://localhost:3000"})
+	@GetMapping("/count")
+	public ResponseEntity<MemberCountResponseDto> getMemberCount() {
+		Long memberCount = memberService.getMemberCount();
+		return ResponseEntity.ok(new MemberCountResponseDto(memberCount));
 	}
 }

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/MemberCountResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/MemberCountResponseDto.java
@@ -1,0 +1,11 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberCountResponseDto {
+
+	private Long memberCount;
+}

--- a/src/main/java/com/YOGIITSU/service/MemberService.java
+++ b/src/main/java/com/YOGIITSU/service/MemberService.java
@@ -193,4 +193,13 @@ public class MemberService {
 		// 7. 사용된 인증 메시지 삭제 (재사용 방지)
 		emailMessageRepository.delete(emailMessage);
 	}
+
+	/**
+	 * 전체 회원 수 조회 메서드
+	 *
+	 * @return 전체 회원 수
+	 */
+	public Long getMemberCount() {
+		return memberRepository.count();
+	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/member-count` → `develop`

### 변경 사항
- 요기있수 웹사이트 **About 페이지**에 들어갈 **실시간 회원 수** 표시 기능 추가
- **[GET] `/members/count`** 엔드포인트 추가 및 구현
### 테스트 결과
- 엔드포인트 호출 시 현재 회원 수가 **정상적으로 반환**됨을 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 멤버의 총 개수를 조회할 수 있는 새로운 API 기능이 추가되었습니다. 웹 애플리케이션에서 현재 멤버 수 정보를 실시간으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->