### PR TITLE
fix: 토큰 재발급 엔드포인트 인증 없이 허용

### DIFF
--- a/src/main/java/com/YOGIITSU/config/SecurityConfig.java
+++ b/src/main/java/com/YOGIITSU/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
 					"/swagger-resources/**",
 					"/webjars/**",
 					"/members/find-password",
-					"/api/auth/google/verify"
+					"/api/auth/google/verify",
+					"/auth/reissue"
 				).permitAll()
 
 				// 로그아웃은 인증된 사용자만 가능

--- a/src/main/java/com/YOGIITSU/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/YOGIITSU/jwt/JwtAuthenticationFilter.java
@@ -47,6 +47,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 			return;
 		}
 
+		// 토큰 재발급 경로는 토큰 검증 생략 (재발급 API에서 처리)
+		if (path.equals("/auth/reissue")) {
+			log.info("Skipping token validation for reissue request - URI: {}", path);
+			chain.doFilter(request, response);
+			return;
+		}
+
 		try {
 			// 1. Request Header 에서 JWT 토큰 추출
 			String token = resolveToken(httpRequest);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/auto-login` → `develop`

### 변경 사항
#### 문제
AccessToken 만료(1시간) 후 RefreshToken이 유효함에도 자동로그인이 해제되는 문제

#### 원인
- SecurityConfig에서 모든 요청을 `permitAll()`로 설정하여 토큰 만료 시 401 에러가 발생하지 않음
- 프론트엔드가 토큰 만료를 감지하지 못해 자동 재발급 시도 불가

### 테스트 결과
#### 수동 테스트
- [x] 로그인 후 AccessToken 만료 전: 정상 API 호출 성공
- [x] AccessToken 만료 후 API 호출: 401 TOKEN_EXPIRED 응답 확인
- [x] `/auth/reissue` 호출: 새 토큰 발급 성공
- [x] 새 토큰으로 API 재호출: 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 토큰 재발급 엔드포인트 추가: "/auth/reissue"를 통해 인증 토큰을 재발급할 수 있습니다.
* 재발급 요청 처리 최적화: 토큰 재발급 요청이 신속하게 처리되도록 인증 필터가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->