### PR TITLE
feat: 리뷰 리스트 페이지네이션 추가

### DIFF
--- a/src/main/java/com/YOGIITSU/controller/ReviewController.java
+++ b/src/main/java/com/YOGIITSU/controller/ReviewController.java
@@ -1,10 +1,10 @@
 package com.YOGIITSU.controller;
 
 import com.YOGIITSU.dto.RequestDto.ReviewCreateRequestDto;
+import com.YOGIITSU.dto.ResponseDto.ReviewPageResponseDto;
 import com.YOGIITSU.dto.ResponseDto.ReviewResponseDto;
 import com.YOGIITSU.service.ReviewService;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,9 +14,10 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/reviews")
@@ -27,10 +28,24 @@ public class ReviewController {
 
 	private final ReviewService reviewService;
 
+	private static final int DEFAULT_PAGE = 1;
+	private static final int DEFAULT_LIMIT = 6;
+
 	@GetMapping
-	public ResponseEntity<List<ReviewResponseDto>> getAllReviews() {
-		List<ReviewResponseDto> reviews = reviewService.getAllReviews();
-		return ResponseEntity.ok(reviews);
+	public ResponseEntity<ReviewPageResponseDto> getAllReviews(
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "6") int limit
+	) {
+		// 페이지와 limit 유효성 검사
+		if (page < 1) {
+			page = DEFAULT_PAGE;
+		}
+		if (limit < 1) {
+			limit = DEFAULT_LIMIT;
+		}
+
+		ReviewPageResponseDto response = reviewService.getReviewsWithPagination(page, limit);
+		return ResponseEntity.ok(response);
 	}
 
 	@PostMapping

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/PaginationInfo.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/PaginationInfo.java
@@ -1,0 +1,19 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaginationInfo {
+
+	private int page;
+	private int totalPages;
+	private long totalCount;
+	private int limit;
+}
+

--- a/src/main/java/com/YOGIITSU/dto/ResponseDto/ReviewPageResponseDto.java
+++ b/src/main/java/com/YOGIITSU/dto/ResponseDto/ReviewPageResponseDto.java
@@ -1,0 +1,18 @@
+package com.YOGIITSU.dto.ResponseDto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewPageResponseDto {
+
+	private List<ReviewResponseDto> reviews;
+	private PaginationInfo pagination;
+}
+

--- a/src/main/java/com/YOGIITSU/repository/ReviewRepository.java
+++ b/src/main/java/com/YOGIITSU/repository/ReviewRepository.java
@@ -2,6 +2,8 @@ package com.YOGIITSU.repository;
 
 import com.YOGIITSU.entity.Review;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +12,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 	// 최신순으로 모든 리뷰 조회 (새 리뷰는 맨 첫번째)
 	List<Review> findAllByOrderByCreatedAtDesc();
+
+	// 최신순으로 페이지네이션된 리뷰 조회
+	Page<Review> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
 }

--- a/src/main/java/com/YOGIITSU/service/ReviewService.java
+++ b/src/main/java/com/YOGIITSU/service/ReviewService.java
@@ -1,6 +1,8 @@
 package com.YOGIITSU.service;
 
 import com.YOGIITSU.dto.RequestDto.ReviewCreateRequestDto;
+import com.YOGIITSU.dto.ResponseDto.PaginationInfo;
+import com.YOGIITSU.dto.ResponseDto.ReviewPageResponseDto;
 import com.YOGIITSU.dto.ResponseDto.ReviewResponseDto;
 import com.YOGIITSU.entity.Review;
 import com.YOGIITSU.exception.resource.ReviewNotFoundException;
@@ -9,6 +11,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +30,27 @@ public class ReviewService {
 		return reviewRepository.findAllByOrderByCreatedAtDesc().stream()
 			.map(ReviewResponseDto::from)
 			.collect(Collectors.toList());
+	}
+
+	public ReviewPageResponseDto getReviewsWithPagination(int page, int limit) {
+		Pageable pageable = PageRequest.of(page - 1, limit);
+		Page<Review> reviewPage = reviewRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+		List<ReviewResponseDto> reviews = reviewPage.getContent().stream()
+			.map(ReviewResponseDto::from)
+			.collect(Collectors.toList());
+
+		PaginationInfo pagination = PaginationInfo.builder()
+			.page(page)
+			.totalPages(reviewPage.getTotalPages())
+			.totalCount(reviewPage.getTotalElements())
+			.limit(limit)
+			.build();
+
+		return ReviewPageResponseDto.builder()
+			.reviews(reviews)
+			.pagination(pagination)
+			.build();
 	}
 
 	@Transactional


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/website` → `develop`

### 변경 사항
- 웹사이트 리뷰 페이지에 페이지네이션 기능 추가
- 1 page에 리뷰 6개

### 테스트 결과
- 로컬에서 페이지네이션 프론트 연동 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* 리뷰 목록 조회에 페이지네이션 기능이 추가되었습니다.
* 페이지 번호와 페이지당 항목 수를 지정하여 리뷰를 조회할 수 있습니다.
* 페이지네이션 정보(현재 페이지, 총 페이지 수, 전체 항목 수)가 응답에 함께 포함됩니다.
* 기본값은 첫 번째 페이지에서 페이지당 6개의 리뷰입니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->