### PR TITLE
fix: springdoc-openapi 버전 2.6.0으로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.jsoup:jsoup:1.17.2'
 	implementation "net.javacrumbs.shedlock:shedlock-spring:5.10.0"


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/chatbot-version-update` → `develop`

### 변경 사항
- springdoc-openapi-starter-webmvc-ui 버전 2.0.2 → 2.6.0으로 업데이트

### 테스트 결과
- 로컬 서버 정상 기동 확인
- Swagger UI 정상 접근 확인
- OpenAI 관련 기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * OpenAPI UI 라이브러리가 업데이트되어 API 문서 조회 기능의 안정성과 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->