### PR TITLE
fix: Firebase 서비스 계정 키를 파일 경로 방식으로 전달하도록 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,12 @@ services:
       - "8081:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=dev
+      - FIREBASE_SERVICE_ACCOUNT_PATH=/run/secrets/firebase-service-account.json
     env_file:
       - ./.env
     volumes:
       - /var/log/yogiitsu/dev:/var/log/yogiitsu/dev
+      - /home/ubuntu/YOGIITSU/firebase-service-account.json:/run/secrets/firebase-service-account.json:ro
     restart: always
 
   yogiitsu-prod:
@@ -23,8 +25,10 @@ services:
       - "8080:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - FIREBASE_SERVICE_ACCOUNT_PATH=/run/secrets/firebase-service-account.json
     env_file:
       - ./.env
     volumes:
       - /var/log/yogiitsu/prod:/var/log/yogiitsu/prod
+      - /home/ubuntu/YOGIITSU/firebase-service-account.json:/run/secrets/firebase-service-account.json:ro
     restart: always

--- a/src/main/java/com/YOGIITSU/config/FirebaseConfig.java
+++ b/src/main/java/com/YOGIITSU/config/FirebaseConfig.java
@@ -3,9 +3,8 @@ package com.YOGIITSU.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,23 +14,27 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class FirebaseConfig {
 
-	@Value("${firebase.service-account-json:}")
-	private String serviceAccountJson;
+	@Value("${firebase.service-account-path:}")
+	private String serviceAccountPath;
 
 	@Bean
 	public FirebaseApp firebaseApp() throws IOException {
-		if (serviceAccountJson == null || serviceAccountJson.isBlank()) {
-			log.warn("FIREBASE_SERVICE_ACCOUNT_JSON 환경변수가 설정되지 않았습니다. FCM 기능이 비활성화됩니다.");
+		if (serviceAccountPath == null || serviceAccountPath.isBlank()) {
+			log.warn("FIREBASE_SERVICE_ACCOUNT_PATH 환경변수가 설정되지 않았습니다. FCM 기능이 비활성화됩니다.");
 			return null;
 		}
 		if (!FirebaseApp.getApps().isEmpty()) {
 			return FirebaseApp.getInstance();
 		}
-		GoogleCredentials credentials = GoogleCredentials.fromStream(
-			new ByteArrayInputStream(serviceAccountJson.getBytes(StandardCharsets.UTF_8)));
+		GoogleCredentials credentials;
+		try (FileInputStream fis = new FileInputStream(serviceAccountPath)) {
+			credentials = GoogleCredentials.fromStream(fis);
+		}
 		FirebaseOptions options = FirebaseOptions.builder()
 			.setCredentials(credentials)
 			.build();
-		return FirebaseApp.initializeApp(options);
+		FirebaseApp app = FirebaseApp.initializeApp(options);
+		log.info("FirebaseApp initialized successfully. path={}", serviceAccountPath);
+		return app;
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,4 +108,4 @@ apple:
   private-key-content: ${APPLE_PRIVATE_KEY_CONTENT}
   
 firebase:
-  service-account-json: ${FIREBASE_SERVICE_ACCOUNT_JSON}
+  service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/#215` → `develop`

### 변경 사항
- 문제
   - `FIREBASE_SERVICE_ACCOUNT_JSON`에 JSON 전체 내용(개행, 특수문자 포함)을 저장하면 Docker Compose가 .env 파일을 파싱하지 못해 Firebase 환경변수가 컨테이너에 전달되지 않는 문제가 발생했습니다.

- 해결
   - 서버에 `firebase-service-account.json` 파일을 영구 보관하고, .env에는 파일 경로만 전달하는 방식으로 변경했습니다.

### 테스트 결과
- FCM 알림 정상 전송 확인

#### 배포 후 확인
  - 컨테이너 내 /run/secrets/firebase-service-account.json 마운트 확인
  - FirebaseApp initialized successfully. path=... 로그 출력 확인